### PR TITLE
Frontend Prototype + Lobby (LAN and Internet)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,9 @@
 [submodule "externals/RakNet"]
 	path = externals/RakNet
 	url = git://github.com/OculusVR/RakNet
+[submodule "externals/json"]
+	path = externals/json
+	url = git://github.com/nlohmann/json
+[submodule "externals/cpr"]
+	path = externals/cpr
+	url = git://github.com/whoshuu/cpr

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,21 +8,41 @@ set(RAKNET_PREFIX "${PROJECT_SOURCE_DIR}/externals/RakNet")
 include_directories(${RAKNET_PREFIX}/Source)
 add_subdirectory(${RAKNET_PREFIX})
 
+set(JSON_PREFIX "${PROJECT_SOURCE_DIR}/externals/json")
+include_directories(${JSON_PREFIX}/src)
+
+#set(RESTCLIENT_PREFIX "${PROJECT_SOURCE_DIR}/externals/RestClient")
+#include_directories(${RESTCLIENT_PREFIX}/include)
+#add_subdirectory(${RESTCLIENT_PREFIX})
+
+#set(CPPRESTSDK_PREFIX "${PROJECT_SOURCE_DIR}/externals/cpprestsdk")
+#include_directories(${CPPRESTSDK_PREFIX}/Release/include)
+#add_subdirectory(${CPPRESTSDK_PREFIX}/Release)
+
+set(USE_SYSTEM_CURL ON CACHE BOOL "")
+set(BUILD_CPR_TESTS OFF CACHE BOOL "")
+set(CPR_PREFIX "${PROJECT_SOURCE_DIR}/externals/cpr")
+add_subdirectory(${CPR_PREFIX})
+include_directories(${CPR_INCLUDE_DIRS})
+
 include_directories("${PROJECT_SOURCE_DIR}/include")
 
 set(SRCS
     src/room.cpp
     src/room_member.cpp
+    src/lobby.cpp
     )
 
 set(HEADERS
     include/tunnler/room.h
     include/tunnler/room_member.h
     include/tunnler/room_message_types.h
+    include/tunnler/lobby.h
     include/tunnler/tunnler.h
     )
 
 add_library(tunnler STATIC ${SRCS} ${HEADERS})
-target_link_libraries(tunnler RakNetLibStatic)
+target_link_libraries(tunnler RakNetLibStatic ${CPR_LIBRARIES})
 
 add_subdirectory(src/frontend)
+add_subdirectory(src/samples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,3 +24,5 @@ set(HEADERS
 
 add_library(tunnler STATIC ${SRCS} ${HEADERS})
 target_link_libraries(tunnler RakNetLibStatic)
+
+add_subdirectory(src/frontend)

--- a/cmake/Modules/CreateDirectoryGroups.cmake
+++ b/cmake/Modules/CreateDirectoryGroups.cmake
@@ -1,0 +1,15 @@
+# This function should be passed a list of all files in a target. It will automatically generate
+# file groups following the directory hierarchy, so that the layout of the files in IDEs matches the
+# one in the filesystem.
+function(create_directory_groups)
+    # Place any files that aren't in the source list in a separate group so that they don't get in
+    # the way.
+    source_group("Other Files" REGULAR_EXPRESSION ".")
+
+    foreach(file_name ${ARGV})
+        get_filename_component(dir_name "${file_name}" PATH)
+        # Group names use '\' as a separator even though the entire rest of CMake uses '/'...
+        string(REPLACE "/" "\\" group_name "${dir_name}")
+        source_group("${group_name}" FILES "${file_name}")
+    endforeach()
+endfunction()

--- a/include/tunnler/lobby.h
+++ b/include/tunnler/lobby.h
@@ -1,0 +1,93 @@
+// Copyright 2017 Tunnler Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+//
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "MessageIdentifiers.h"
+
+#include "RakPeerInterface.h"
+#include "RakPeerInterface.h"
+#include "RakNetTypes.h"
+#include "GetTime.h"
+#include "BitStream.h"
+
+#include <assert.h>
+#include <cstdio>
+#include <cstring>
+#include <stdlib.h>
+
+//FIXME: Maybe seperate this into an interface and have LocalNetworkLobby and MasterServerLobby ?
+class Lobby {
+
+// Pointers to the interfaces of our server and client.
+// Note we can easily have both in the same program
+RakNet::RakPeerInterface *client = RakNet::RakPeerInterface::GetInstance();
+bool b;
+char str[256];
+RakNet::TimeMS quit_time;
+// Holds packets
+RakNet::Packet* p;  
+
+public:
+
+struct RoomInformation {
+  std::string name;
+  //FIXME: Can we somehow extract a game title id from UDS or something?
+  //FIXME: Can we somehow check the NWM cryptokey for validity?
+  unsigned int users;
+  unsigned int max_users;
+};
+
+struct FoundRoom {
+  bool local; // Wether this was retrieved from a master list or LAN scan
+  std::string server;
+  unsigned int server_port;
+    //FIXME: Store some timestamp when this was last alive, if it's too old it should probably be removed
+  std::shared_ptr<RoomInformation> information;
+  unsigned int ping;
+};
+
+private:
+
+std::vector<FoundRoom> foundRooms;
+
+public:
+
+~Lobby();
+
+std::string MasterServer = "http://127.0.0.1:8000/"; //FIXME: Make controllable
+const std::string Path = "/rooms.php";
+
+std::vector<FoundRoom> GetRooms();
+// Returns a token
+std::string CreateRoom(std::string server, uint16_t server_port);
+bool UpdateRoom(std::string token);
+
+bool DestroyRoom(std::string token);
+
+// This might take some time to process
+void sendPing();
+
+void updateFoundRooms(unsigned int expiration_time = 5000);
+
+RoomInformation GetRoomInformation(std::string server, uint16_t server_port, uint16_t client_port = 0);
+
+//FIXME: Make the parameter some chrono:: crap
+std::vector<FoundRoom> retrieveFoundRooms();
+
+//FIXME: Use default server port here
+void StartScan(unsigned int server_port = 1234, unsigned int client_port = 0);
+void StopScan();
+
+private:
+
+//static void processInternetData(std::string masterServer);
+void processLocalNetworkData();
+
+};

--- a/include/tunnler/room_member.h
+++ b/include/tunnler/room_member.h
@@ -132,10 +132,16 @@ private:
     MacAddress mac_address; ///< The mac_address of this member.
 
     /**
+     * Extracts a ChatPacket from a received RakNet packet and adds it to the proper queue.
+     * @param packet The RakNet packet that was received.
+     */
+    void HandleChatPacket(const RakNet::Packet* packet);
+
+    /**
      * Extracts a WifiPacket from a received RakNet packet and adds it to the proper queue.
      * @param packet The RakNet packet that was received.
      */
-    void HandleWifiPackets(const RakNet::Packet* packet);
+    void HandleWifiPacket(const RakNet::Packet* packet);
 
     /**
      * Extracts RoomInformation and MemberInformation from a received RakNet packet.
@@ -160,6 +166,10 @@ private:
     // cause an overflow in UDS::RecvBeaconBroadcastData.
     static const size_t MaxBeaconQueueSize = 25;
 
+    /// Max size of the chat message queue before the oldest entry is expunged.
+    static const size_t MaxChatQueueSize = 10;
+
+    std::mutex chat_mutex;               ///< Mutex to protect access to the chat message queue.
     std::deque<ChatEntry> chat_queue;    ///< List of all chat messages received since last PopChatEntries was called
     std::mutex data_mutex;             ///< Mutex to protect access to the data queue.
     std::deque<WifiPacket> data_queue;   ///< List of all received 802.11 frames with type `Data`

--- a/src/frontend/CMakeLists.txt
+++ b/src/frontend/CMakeLists.txt
@@ -28,6 +28,7 @@ set(HEADERS
 #create_directory_groups(${SRCS} ${HEADERS})
 
 add_executable(frontend ${SRCS} ${HEADERS})
+target_link_libraries(frontend tunnler)
 target_link_libraries(frontend ${FRONTEND_QT_LIBS})
 target_link_libraries(frontend ${PLATFORM_LIBRARIES} Threads::Threads)
 

--- a/src/frontend/CMakeLists.txt
+++ b/src/frontend/CMakeLists.txt
@@ -1,0 +1,34 @@
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/Modules/")
+
+find_package(Qt5 REQUIRED COMPONENTS Widgets ${QT_PREFIX_HINT})
+set(FRONTEND_QT_LIBS Qt5::Widgets)
+
+# Prefer the -pthread flag on Linux.
+set (THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+
+set(SRCS
+            main.cpp
+            room_list.cpp
+            room_view_window.cpp
+            room_list_window.cpp
+            )
+
+set(HEADERS
+            main.h
+            room_list.h
+            room_list_p.h
+            room_view_window.h
+            room_list_window.h
+            )
+
+#create_directory_groups(${SRCS} ${HEADERS})
+
+add_executable(frontend ${SRCS} ${HEADERS})
+target_link_libraries(frontend ${FRONTEND_QT_LIBS})
+target_link_libraries(frontend ${PLATFORM_LIBRARIES} Threads::Threads)
+
+

--- a/src/frontend/main.cpp
+++ b/src/frontend/main.cpp
@@ -1,0 +1,46 @@
+// Copyright 2017 Tunnler Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <cinttypes>
+#include <clocale>
+#include <memory>
+#include <thread>
+#define QT_NO_OPENGL
+#include <QDesktopWidget>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QtGui>
+#include <QtWidgets>
+#include "main.h"
+#include "room_view_window.h"
+#include "room_list_window.h"
+
+#ifdef QT_STATICPLUGIN
+Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+#endif
+
+
+#ifdef main
+#undef main
+#endif
+
+int main(int argc, char* argv[]) {
+    // Init settings params
+    QCoreApplication::setOrganizationName("Tunnler team");
+    QCoreApplication::setApplicationName("Tunnler");
+
+    QApplication::setAttribute(Qt::AA_X11InitThreads);
+    QApplication app(argc, argv);
+
+    // Qt changes the locale and causes issues in float conversion using std::to_string()
+    setlocale(LC_ALL, "C");
+
+    RoomListWindow room_list_window;
+    room_list_window.show();
+
+    RoomViewWindow room_view_window;
+    room_view_window.show();
+
+    return app.exec();
+}

--- a/src/frontend/main.h
+++ b/src/frontend/main.h
@@ -1,0 +1,15 @@
+// Copyright 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#define u64 uint64_t
+
+#ifndef _CITRA_QT_MAIN_HXX_
+#define _CITRA_QT_MAIN_HXX_
+
+#include <memory>
+#include <QMainWindow>
+#include <QLabel>
+#include <QTimer>
+
+#endif // _CITRA_QT_MAIN_HXX_

--- a/src/frontend/room_list.cpp
+++ b/src/frontend/room_list.cpp
@@ -42,15 +42,19 @@ RoomList::RoomList(QWidget* parent) : QWidget{parent} {
     item_model->setHeaderData(COLUMN_PING, Qt::Horizontal, "Ping");
     item_model->setHeaderData(COLUMN_FLAGS, Qt::Horizontal, "Flags"); // Password | LAN
 
-#if 0
     connect(tree_view, &QTreeView::activated, this, &RoomList::ValidateEntry);
+    connect(tree_view->selectionModel(), SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)), this, SLOT(SelectionChanged(const QItemSelection&,const QItemSelection&)));
+#if 0
     connect(tree_view, &QTreeView::customContextMenuRequested, this, &RoomList::PopupContextMenu);
     connect(&watcher, &QFileSystemWatcher::directoryChanged, this, &RoomList::RefreshGameDirectory);
+#endif
 
     // We must register all custom types with the Qt Automoc system so that we are able to use it
     // with signals/slots. In this case, QList falls under the umbrells of custom types.
     qRegisterMetaType<QList<QStandardItem*>>("QList<QStandardItem*>");
-#endif
+
+    tree_view->header()->setStretchLastSection(false);
+    tree_view->header()->setSectionResizeMode(COLUMN_NAME, QHeaderView::Stretch);   
 
     layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(tree_view);
@@ -62,25 +66,63 @@ RoomList::~RoomList() {
 }
 
 #if 0
+//FIXME: Stolen from the internet
+bool SortFilterProxyModel::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const
+{
+    QList<QModelIndex> children;
+    children << sourceModel()->index(source_row, 0, source_parent);
+ 
+    bool show = false;
+    for(int i = 0; i < children.length(); i++)
+    {
+        if(show) break;
+ 
+        // Add sub Nodos
+        //
+        for(int c = 0; c < sourceModel()->rowCount(children[i]) ;c++)
+            children.append(children[i].child(c,0));
+ 
+        QString type = sourceModel()->data(children[i], Qt::DisplayRole).toString();
+        show = type.contains(filterRegExp());        
+    }
+    return show;
+}
+#endif
+
+//#if 0
+
+void RoomList::ClearSelection() {
+    tree_view->clearSelection();
+}
 
 void RoomList::AddEntry(const QList<QStandardItem*>& entry_items) {
     item_model->invisibleRootItem()->appendRow(entry_items);
 }
 
+void RoomList::SelectionChanged(const QItemSelection&,const QItemSelection&) {
+    //FIXME: get selection etc.
+    emit RoomChosen("google.com", 1337, false); //FIXME!
+}
+
 void RoomList::ValidateEntry(const QModelIndex& item) {
     // We don't care about the individual QStandardItem that was selected, but its row.
     int row = item_model->itemFromIndex(item)->row();
-    QStandardItem* child_file = item_model->invisibleRootItem()->child(row, COLUMN_NAME);
-    QString file_path = child_file->data(RoomListItemPath::FullPathRole).toString();
+    QStandardItem* child_server = item_model->invisibleRootItem()->child(row, COLUMN_SERVER);
+    QString server = child_server->data(/*RoomListItemPath::FullPathRole*/).toString();
+
+#if 0
+
 
     if (file_path.isEmpty())
         return;
     std::string std_file_path(file_path.toStdString());
     if (!FileUtil::Exists(std_file_path) || FileUtil::IsDirectory(std_file_path))
         return;
-    emit GameChosen(file_path);
+#endif
+    emit RoomChosen(server, 1337, true); //FIXME!
 }
 
+#if 0
 void RoomList::DonePopulating() {
     tree_view->setEnabled(true);
 }

--- a/src/frontend/room_list.cpp
+++ b/src/frontend/room_list.cpp
@@ -1,0 +1,245 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <QFileInfo>
+#include <QHeaderView>
+#include <QMenu>
+#include <QThreadPool>
+#include <QVBoxLayout>
+/*
+#include "common/common_paths.h"
+#include "common/logging/log.h"
+#include "common/string_util.h"
+#include "core/loader/loader.h"
+#include "ui_settings.h"
+*/
+
+#include "room_list.h"
+#include "room_list_p.h"
+
+RoomList::RoomList(QWidget* parent) : QWidget{parent} {
+    QVBoxLayout* layout = new QVBoxLayout;
+
+    tree_view = new QTreeView;
+    item_model = new QStandardItemModel(tree_view);
+    tree_view->setModel(item_model);
+
+    tree_view->setAlternatingRowColors(true);
+    tree_view->setSelectionMode(QHeaderView::SingleSelection);
+    tree_view->setSelectionBehavior(QHeaderView::SelectRows);
+    tree_view->setVerticalScrollMode(QHeaderView::ScrollPerPixel);
+    tree_view->setHorizontalScrollMode(QHeaderView::ScrollPerPixel);
+    tree_view->setSortingEnabled(true);
+    tree_view->setEditTriggers(QHeaderView::NoEditTriggers);
+    tree_view->setUniformRowHeights(true);
+    tree_view->setContextMenuPolicy(Qt::CustomContextMenu);
+
+    item_model->insertColumns(0, COLUMN_COUNT);
+    item_model->setHeaderData(COLUMN_NAME, Qt::Horizontal, "Name");
+    item_model->setHeaderData(COLUMN_PLAYERS, Qt::Horizontal, "Members");
+    item_model->setHeaderData(COLUMN_SERVER, Qt::Horizontal, "Server");
+    item_model->setHeaderData(COLUMN_PING, Qt::Horizontal, "Ping");
+    item_model->setHeaderData(COLUMN_FLAGS, Qt::Horizontal, "Flags"); // Password | LAN
+
+#if 0
+    connect(tree_view, &QTreeView::activated, this, &RoomList::ValidateEntry);
+    connect(tree_view, &QTreeView::customContextMenuRequested, this, &RoomList::PopupContextMenu);
+    connect(&watcher, &QFileSystemWatcher::directoryChanged, this, &RoomList::RefreshGameDirectory);
+
+    // We must register all custom types with the Qt Automoc system so that we are able to use it
+    // with signals/slots. In this case, QList falls under the umbrells of custom types.
+    qRegisterMetaType<QList<QStandardItem*>>("QList<QStandardItem*>");
+#endif
+
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->addWidget(tree_view);
+    setLayout(layout);
+}
+
+RoomList::~RoomList() {
+    emit ShouldCancelWorker();
+}
+
+#if 0
+
+void RoomList::AddEntry(const QList<QStandardItem*>& entry_items) {
+    item_model->invisibleRootItem()->appendRow(entry_items);
+}
+
+void RoomList::ValidateEntry(const QModelIndex& item) {
+    // We don't care about the individual QStandardItem that was selected, but its row.
+    int row = item_model->itemFromIndex(item)->row();
+    QStandardItem* child_file = item_model->invisibleRootItem()->child(row, COLUMN_NAME);
+    QString file_path = child_file->data(RoomListItemPath::FullPathRole).toString();
+
+    if (file_path.isEmpty())
+        return;
+    std::string std_file_path(file_path.toStdString());
+    if (!FileUtil::Exists(std_file_path) || FileUtil::IsDirectory(std_file_path))
+        return;
+    emit GameChosen(file_path);
+}
+
+void RoomList::DonePopulating() {
+    tree_view->setEnabled(true);
+}
+
+void RoomList::PopupContextMenu(const QPoint& menu_location) {
+    QModelIndex item = tree_view->indexAt(menu_location);
+    if (!item.isValid())
+        return;
+
+    int row = item_model->itemFromIndex(item)->row();
+    QStandardItem* child_file = item_model->invisibleRootItem()->child(row, COLUMN_NAME);
+    u64 program_id = child_file->data(RoomListItemPath::ProgramIdRole).toULongLong();
+
+    QMenu context_menu;
+    QAction* open_save_location = context_menu.addAction(tr("Open Save Data Location"));
+    open_save_location->setEnabled(program_id != 0);
+    connect(open_save_location, &QAction::triggered,
+            [&]() { emit OpenSaveFolderRequested(program_id); });
+    context_menu.exec(tree_view->viewport()->mapToGlobal(menu_location));
+}
+
+void RoomList::PopulateAsync(const QString& dir_path, bool deep_scan) {
+    if (!FileUtil::Exists(dir_path.toStdString()) ||
+        !FileUtil::IsDirectory(dir_path.toStdString())) {
+        LOG_ERROR(Frontend, "Could not find game list folder at %s", dir_path.toLocal8Bit().data());
+        return;
+    }
+
+    tree_view->setEnabled(false);
+    // Delete any rows that might already exist if we're repopulating
+    item_model->removeRows(0, item_model->rowCount());
+
+    emit ShouldCancelWorker();
+
+    auto watch_dirs = watcher.directories();
+    if (!watch_dirs.isEmpty()) {
+        watcher.removePaths(watch_dirs);
+    }
+    UpdateWatcherList(dir_path.toStdString(), deep_scan ? 256 : 0);
+    RoomListWorker* worker = new RoomListWorker(dir_path, deep_scan);
+
+    connect(worker, &RoomListWorker::EntryReady, this, &RoomList::AddEntry, Qt::QueuedConnection);
+    connect(worker, &RoomListWorker::Finished, this, &RoomList::DonePopulating,
+            Qt::QueuedConnection);
+    // Use DirectConnection here because worker->Cancel() is thread-safe and we want it to cancel
+    // without delay.
+    connect(this, &RoomList::ShouldCancelWorker, worker, &RoomListWorker::Cancel,
+            Qt::DirectConnection);
+
+    QThreadPool::globalInstance()->start(worker);
+    current_worker = std::move(worker);
+}
+
+void RoomList::SaveInterfaceLayout() {
+    UISettings::values.gamelist_header_state = tree_view->header()->saveState();
+}
+
+void RoomList::LoadInterfaceLayout() {
+    auto header = tree_view->header();
+    if (!header->restoreState(UISettings::values.gamelist_header_state)) {
+        // We are using the name column to display icons and titles
+        // so make it as large as possible as default.
+        header->resizeSection(COLUMN_NAME, header->width());
+    }
+
+    item_model->sort(header->sortIndicatorSection(), header->sortIndicatorOrder());
+}
+
+const QStringList RoomList::supported_file_extensions = {"3ds", "3dsx", "elf", "axf",
+                                                         "cci", "cxi",  "app"};
+
+static bool HasSupportedFileExtension(const std::string& file_name) {
+    QFileInfo file = QFileInfo(file_name.c_str());
+    return RoomList::supported_file_extensions.contains(file.suffix(), Qt::CaseInsensitive);
+}
+
+void RoomList::RefreshGameDirectory() {
+    if (!UISettings::values.gamedir.isEmpty() && current_worker != nullptr) {
+        LOG_INFO(Frontend, "Change detected in the games directory. Reloading game list.");
+        PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
+    }
+}
+
+/**
+ * Adds the game list folder to the QFileSystemWatcher to check for updates.
+ *
+ * The file watcher will fire off an update to the game list when a change is detected in the game
+ * list folder.
+ *
+ * Notice: This method is run on the UI thread because QFileSystemWatcher is not thread safe and
+ * this function is fast enough to not stall the UI thread. If performance is an issue, it should
+ * be moved to another thread and properly locked to prevent concurrency issues.
+ *
+ * @param dir folder to check for changes in
+ * @param recursion 0 if recursion is disabled. Any positive number passed to this will add each
+ *        directory recursively to the watcher and will update the file list if any of the folders
+ *        change. The number determines how deep the recursion should traverse.
+ */
+void RoomList::UpdateWatcherList(const std::string& dir, unsigned int recursion) {
+    const auto callback = [this, recursion](unsigned* num_entries_out, const std::string& directory,
+                                            const std::string& virtual_name) -> bool {
+        std::string physical_name = directory + DIR_SEP + virtual_name;
+
+        if (FileUtil::IsDirectory(physical_name)) {
+            UpdateWatcherList(physical_name, recursion - 1);
+        }
+        return true;
+    };
+
+    watcher.addPath(QString::fromStdString(dir));
+    if (recursion > 0) {
+        FileUtil::ForeachDirectoryEntry(nullptr, dir, callback);
+    }
+}
+
+void RoomListWorker::AddFstEntriesToRoomList(const std::string& dir_path, unsigned int recursion) {
+    const auto callback = [this, recursion](unsigned* num_entries_out, const std::string& directory,
+                                            const std::string& virtual_name) -> bool {
+        std::string physical_name = directory + DIR_SEP + virtual_name;
+
+        if (stop_processing)
+            return false; // Breaks the callback loop.
+
+        if (!FileUtil::IsDirectory(physical_name) && HasSupportedFileExtension(physical_name)) {
+            std::unique_ptr<Loader::AppLoader> loader = Loader::GetLoader(physical_name);
+            if (!loader)
+                return true;
+
+            std::vector<u8> smdh;
+            loader->ReadIcon(smdh);
+
+            u64 program_id = 0;
+            loader->ReadProgramId(program_id);
+
+            emit EntryReady({
+                new RoomListItemPath(QString::fromStdString(physical_name), smdh, program_id),
+                new RoomListItem(
+                    QString::fromStdString(Loader::GetFileTypeString(loader->GetFileType()))),
+                new RoomListItemSize(FileUtil::GetSize(physical_name)),
+            });
+        } else if (recursion > 0) {
+            AddFstEntriesToRoomList(physical_name, recursion - 1);
+        }
+
+        return true;
+    };
+
+    FileUtil::ForeachDirectoryEntry(nullptr, dir_path, callback);
+}
+
+void RoomListWorker::run() {
+    stop_processing = false;
+    AddFstEntriesToRoomList(dir_path.toStdString(), deep_scan ? 256 : 0);
+    emit Finished();
+}
+
+void RoomListWorker::Cancel() {
+    this->disconnect();
+    stop_processing = true;
+}
+
+#endif

--- a/src/frontend/room_list.h
+++ b/src/frontend/room_list.h
@@ -1,0 +1,66 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <cstdint>
+typedef uint64_t u64;
+
+#pragma once
+
+#include <QFileSystemWatcher>
+#include <QModelIndex>
+#include <QSettings>
+#include <QStandardItem>
+#include <QStandardItemModel>
+#include <QString>
+#include <QTreeView>
+#include <QWidget>
+
+class RoomListWorker;
+
+class RoomList : public QWidget {
+    Q_OBJECT
+
+public:
+    enum {
+        COLUMN_NAME,
+        COLUMN_SERVER,
+        COLUMN_PLAYERS,
+        COLUMN_PING,
+        COLUMN_FLAGS,
+        COLUMN_COUNT, // Number of columns
+    };
+
+    explicit RoomList(QWidget* parent = nullptr);
+    ~RoomList() override;
+
+#if 0
+    void PopulateAsync(const QString& dir_path, bool deep_scan);
+
+    void SaveInterfaceLayout();
+    void LoadInterfaceLayout();
+
+    static const QStringList supported_file_extensions;
+#endif
+signals:
+    void GameChosen(QString game_path);
+    void ShouldCancelWorker();
+    void OpenSaveFolderRequested(u64 program_id);
+private:
+#if 0 
+    void AddEntry(const QList<QStandardItem*>& entry_items);
+    void ValidateEntry(const QModelIndex& item);
+    void DonePopulating();
+
+    void PopupContextMenu(const QPoint& menu_location);
+    void UpdateWatcherList(const std::string& path, unsigned int recursion);
+    void RefreshGameDirectory();
+
+
+    RoomListWorker* current_worker = nullptr;
+    QFileSystemWatcher watcher;
+#endif
+
+    QTreeView* tree_view = nullptr;
+    QStandardItemModel* item_model = nullptr;
+};

--- a/src/frontend/room_list.h
+++ b/src/frontend/room_list.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 typedef uint64_t u64;
+typedef uint16_t u16;
 
 #pragma once
 
@@ -43,13 +44,18 @@ public:
     static const QStringList supported_file_extensions;
 #endif
 signals:
-    void GameChosen(QString game_path);
+    void RoomChosen(QString server, u16 serverPort, bool join);
     void ShouldCancelWorker();
     void OpenSaveFolderRequested(u64 program_id);
-private:
-#if 0 
+
+public:
+    void ClearSelection();
     void AddEntry(const QList<QStandardItem*>& entry_items);
+private slots:
+    void SelectionChanged(const QItemSelection&, const QItemSelection&); 
+private:
     void ValidateEntry(const QModelIndex& item);
+#if 0
     void DonePopulating();
 
     void PopupContextMenu(const QPoint& menu_location);

--- a/src/frontend/room_list_p.h
+++ b/src/frontend/room_list_p.h
@@ -1,0 +1,198 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+typedef uint8_t u8;
+
+#include <atomic>
+#include <QImage>
+#include <QRunnable>
+#include <QStandardItem>
+#include <QString>
+#if 0
+#include "citra_qt/util/util.h"
+#include "common/color.h"
+#include "common/string_util.h"
+#include "core/loader/smdh.h"
+#include "video_core/utils.h"
+#endif
+
+/**
+ * Gets the game icon from SMDH data.
+ * @param smdh SMDH data
+ * @param large If true, returns large icon (48x48), otherwise returns small icon (24x24)
+ * @return QPixmap game icon
+ */
+#if 0
+static QPixmap GetQPixmapFromSMDH(const Loader::SMDH& smdh, bool large) {
+    std::vector<u16> icon_data = smdh.GetIcon(large);
+    const uchar* data = reinterpret_cast<const uchar*>(icon_data.data());
+    int size = large ? 48 : 24;
+    QImage icon(data, size, size, QImage::Format::Format_RGB16);
+    return QPixmap::fromImage(icon);
+    return {};
+}
+#endif
+
+/**
+ * Gets the default icon (for games without valid SMDH)
+ * @param large If true, returns large icon (48x48), otherwise returns small icon (24x24)
+ * @return QPixmap default icon
+ */
+static QPixmap GetDefaultIcon(bool large) {
+    int size = large ? 48 : 24;
+    QPixmap icon(size, size);
+    icon.fill(Qt::transparent);
+    return icon;
+}
+
+/**
+ * Gets the short game title from SMDH data.
+ * @param smdh SMDH data
+ * @param language title language
+ * @return QString short title
+ */
+#if 0
+static QString GetQStringShortTitleFromSMDH(const Loader::SMDH& smdh,
+                                            Loader::SMDH::TitleLanguage language) {
+    return QString::fromUtf16(smdh.GetShortTitle(language).data());
+}
+#endif
+
+class GameListItem : public QStandardItem {
+
+public:
+    GameListItem() : QStandardItem() {}
+    GameListItem(const QString& string) : QStandardItem(string) {}
+    virtual ~GameListItem() override {}
+};
+
+/**
+ * A specialization of GameListItem for path values.
+ * This class ensures that for every full path value it holds, a correct string representation
+ * of just the filename (with no extension) will be displayed to the user.
+ * If this class receives valid SMDH data, it will also display game icons and titles.
+ */
+class GameListItemPath : public GameListItem {
+
+public:
+    static const int FullPathRole = Qt::UserRole + 1;
+    static const int TitleRole = Qt::UserRole + 2;
+    static const int ProgramIdRole = Qt::UserRole + 3;
+
+    GameListItemPath() : GameListItem() {}
+    GameListItemPath(const QString& game_path, const std::vector<u8>& smdh_data, u64 program_id)
+        : GameListItem() {
+#if 0
+        setData(game_path, FullPathRole);
+        setData(qulonglong(program_id), ProgramIdRole);
+
+        if (!Loader::IsValidSMDH(smdh_data)) {
+            // SMDH is not valid, set a default icon
+            setData(GetDefaultIcon(true), Qt::DecorationRole);
+            return;
+        }
+
+        Loader::SMDH smdh;
+        memcpy(&smdh, smdh_data.data(), sizeof(Loader::SMDH));
+
+        // Get icon from SMDH
+        setData(GetQPixmapFromSMDH(smdh, true), Qt::DecorationRole);
+
+        // Get title form SMDH
+        setData(GetQStringShortTitleFromSMDH(smdh, Loader::SMDH::TitleLanguage::English),
+                TitleRole);
+#endif
+    }
+
+    QVariant data(int role) const override {
+#if 0
+        if (role == Qt::DisplayRole) {
+            std::string filename;
+            Common::SplitPath(data(FullPathRole).toString().toStdString(), nullptr, &filename,
+                              nullptr);
+            QString title = data(TitleRole).toString();
+            return QString::fromStdString(filename) + (title.isEmpty() ? "" : "\n    " + title);
+        } else {
+            return GameListItem::data(role);
+        }
+#endif
+    }
+};
+
+/**
+ * A specialization of GameListItem for size values.
+ * This class ensures that for every numerical size value it holds (in bytes), a correct
+ * human-readable string representation will be displayed to the user.
+ */
+class GameListItemSize : public GameListItem {
+
+public:
+    static const int SizeRole = Qt::UserRole + 1;
+
+    GameListItemSize() : GameListItem() {}
+    GameListItemSize(const qulonglong size_bytes) : GameListItem() {
+        setData(size_bytes, SizeRole);
+    }
+
+    void setData(const QVariant& value, int role) override {
+#if 0
+        // By specializing setData for SizeRole, we can ensure that the numerical and string
+        // representations of the data are always accurate and in the correct format.
+        if (role == SizeRole) {
+            qulonglong size_bytes = value.toULongLong();
+            GameListItem::setData(ReadableByteSize(size_bytes), Qt::DisplayRole);
+            GameListItem::setData(value, SizeRole);
+        } else {
+            GameListItem::setData(value, role);
+        }
+#endif
+    }
+
+    /**
+     * This operator is, in practice, only used by the TreeView sorting systems.
+     * Override it so that it will correctly sort by numerical value instead of by string
+     * representation.
+     */
+    bool operator<(const QStandardItem& other) const override {
+        return data(SizeRole).toULongLong() < other.data(SizeRole).toULongLong();
+    }
+};
+
+#if 0
+/**
+ * Asynchronous worker object for populating the game list.
+ * Communicates with other threads through Qt's signal/slot system.
+ */
+class GameListWorker : public QObject, public QRunnable {
+    Q_OBJECT
+
+public:
+    GameListWorker(QString dir_path, bool deep_scan)
+        : QObject(), QRunnable(), dir_path(dir_path), deep_scan(deep_scan) {}
+
+public slots:
+    /// Starts the processing of directory tree information.
+    void run() override;
+    /// Tells the worker that it should no longer continue processing. Thread-safe.
+    void Cancel();
+
+signals:
+    /**
+     * The `EntryReady` signal is emitted once an entry has been prepared and is ready
+     * to be added to the game list.
+     * @param entry_items a list with `QStandardItem`s that make up the columns of the new entry.
+     */
+    void EntryReady(QList<QStandardItem*> entry_items);
+    void Finished();
+
+private:
+    QString dir_path;
+    bool deep_scan;
+    std::atomic_bool stop_processing;
+
+    void AddFstEntriesToGameList(const std::string& dir_path, unsigned int recursion = 0);
+};
+#endif

--- a/src/frontend/room_list_window.cpp
+++ b/src/frontend/room_list_window.cpp
@@ -13,6 +13,7 @@
 #include <QtGui>
 #include <QtWidgets>
 #include <QGridLayout>
+#include <QHBoxLayout>
 #include "room_list.h"
 #include "room_list_window.h"
 
@@ -66,7 +67,7 @@ void RoomListWindow::InitializeWidgets() {
 
     //FIXME: Automaticly keep this in sync with the select lobby server
     QWidget* direct_connection_widget = new QWidget();
-    QGridLayout* direct_connection_widget_layout = new QGridLayout();
+    QHBoxLayout* direct_connection_widget_layout = new QHBoxLayout();
     direct_connection_widget->setLayout(direct_connection_widget_layout);
     {
         QLabel* server_label = new QLabel(tr("Server"));
@@ -92,12 +93,25 @@ void RoomListWindow::InitializeWidgets() {
     }
     centralWidgetLayout->addWidget(direct_connection_widget);
 
-    QWidget* filter_widget = new QWidget();
-    QGridLayout* filter_widget_layout = new QGridLayout();
-    filter_widget->setLayout(filter_widget_layout);
+#if 0
 
     room_list = new RoomList();
     centralWidgetLayout->addWidget(room_list);
+
+    for (unsigned i = 0; i < 10; i++) {
+        QList<QStandardItem*> l;
+        for(unsigned int j = 0; j < 5; j++) {
+		        QStandardItem *child = new QStandardItem( QString("Item %0").arg(i)); //, QString("Foo"));
+		        child->setEditable( false );
+            l.append(child);
+        }
+        room_list->AddEntry(l);
+    }
+
+
+    QWidget* filter_widget = new QWidget();
+    QGridLayout* filter_widget_layout = new QGridLayout();
+    filter_widget->setLayout(filter_widget_layout);
 
     QLabel* gameFilterLabel = new QLabel(tr("Game"));
     gameFilter = new QLineEdit();
@@ -131,6 +145,9 @@ void RoomListWindow::InitializeWidgets() {
     filter_widget_layout->addWidget(pingFilter, 2, 1);
 
     centralWidgetLayout->addWidget(filter_widget);
+
+#endif
+
     setCentralWidget(centralWidget);    
 
 #if 1
@@ -161,15 +178,6 @@ emu_speed_label->setText(tr("5 servers found, 3 hidden / filtered."));
 #endif
 
 
-    for (unsigned i = 0; i < 10; i++) {
-        QList<QStandardItem*> l;
-        for(unsigned int j = 0; j < 5; j++) {
-		        QStandardItem *child = new QStandardItem( QString("Item %0").arg(i)); //, QString("Foo"));
-		        child->setEditable( false );
-            l.append(child);
-        }
-        room_list->AddEntry(l);
-    }
 
 
 }
@@ -309,7 +317,11 @@ void RoomListWindow::OnRoomListSelectRoom(QString server, u16 serverPort, bool j
 }
 
 void RoomListWindow::ConnectWidgetEvents() {
+#if 0
     connect(room_list, SIGNAL(RoomChosen(QString, u16, bool)), this, SLOT(OnRoomListSelectRoom(QString, u16, bool)));
+#endif
+
+
 #if 0
     connect(room_list, SIGNAL(OpenSaveFolderRequested(u64)), this,
             SLOT(OnRoomListOpenSaveFolder(u64)));

--- a/src/frontend/room_list_window.cpp
+++ b/src/frontend/room_list_window.cpp
@@ -1,0 +1,362 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <cinttypes>
+#include <clocale>
+#include <memory>
+#include <thread>
+#define QT_NO_OPENGL
+#include <QDesktopWidget>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QtGui>
+#include <QtWidgets>
+#include <QGridLayout>
+#include "room_list.h"
+#include "room_list_window.h"
+
+RoomListWindow::RoomListWindow() {
+#if 0
+    setAcceptDrops(true);
+    ui.setupUi(this);
+    statusBar()->hide();
+#endif
+
+    InitializeWidgets();
+#if 0
+    InitializeDebugWidgets();
+    InitializeRecentFileMenuActions();
+    InitializeHotkeys();
+
+    SetDefaultUIGeometry();
+    RestoreUIState();
+
+    ConnectMenuEvents();
+    ConnectWidgetEvents();
+#endif
+
+    setWindowTitle(QString("Room List"));
+    show();
+
+#if 0
+    room_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
+
+    QStringList args = QApplication::arguments();
+    if (args.length() >= 2) {
+        BootGame(args[1]);
+    }
+#endif
+}
+
+RoomListWindow::~RoomListWindow() {
+#if 0
+    // will get automatically deleted otherwise
+    if (render_window->parent() == nullptr)
+        delete render_window;
+
+    Pica::g_debug_context.reset();
+#endif
+}
+
+void RoomListWindow::InitializeWidgets() {
+    QGridLayout* centralWidgetLayout = new QGridLayout();
+    QWidget* centralWidget = new QWidget();
+    centralWidget->setLayout(centralWidgetLayout);
+
+    //FIXME: Automaticly keep this in sync with the select lobby server
+    QWidget* direct_connection_widget = new QWidget();
+    QGridLayout* direct_connection_widget_layout = new QGridLayout();
+    direct_connection_widget->setLayout(direct_connection_widget_layout);
+    {
+        QLabel* server_label = new QLabel(tr("Server"));
+        QLineEdit* server = new QLineEdit();
+        direct_connection_widget_layout->addWidget(server_label);
+        direct_connection_widget_layout->addWidget(server);
+
+        QLabel* port_label = new QLabel(tr("Port"));
+        QSpinBox* port = new QSpinBox();
+        port->setRange(1, 65535);
+        port->setValue(1234); // FIXME: Pick a proper port and / or retrieve it from tunnler
+        direct_connection_widget_layout->addWidget(port_label);
+        direct_connection_widget_layout->addWidget(port);
+
+        QLabel* nickname_label = new QLabel(tr("Nickname"));
+        QLineEdit* nickname = new QLineEdit();
+        direct_connection_widget_layout->addWidget(nickname_label);
+        direct_connection_widget_layout->addWidget(nickname);
+
+        QPushButton* join_button = new QPushButton(tr("Join room"));
+        direct_connection_widget_layout->addWidget(join_button);
+        //FIXME: Disable if IP is empty
+    }
+    centralWidgetLayout->addWidget(direct_connection_widget);
+
+    QWidget* filter_widget = new QWidget();
+    QGridLayout* filter_widget_layout = new QGridLayout();
+    filter_widget->setLayout(filter_widget_layout);
+
+    room_list = new RoomList();
+    centralWidgetLayout->addWidget(room_list);
+
+    QLabel* gameFilterLabel = new QLabel(tr("Game"));
+    gameFilter = new QLineEdit();
+    filter_widget_layout->addWidget(gameFilterLabel, 0, 0);
+    filter_widget_layout->addWidget(gameFilter, 0, 0);
+
+    QLabel* nameFilterLabel = new QLabel(tr("Name"));
+    nameFilter = new QLineEdit();
+    filter_widget_layout->addWidget(nameFilterLabel, 1, 0);
+    filter_widget_layout->addWidget(nameFilter, 1, 0);
+
+    QCheckBox* show_internet = new QCheckBox(tr("Show internet servers"));
+    filter_widget_layout->addWidget(show_internet, 0, 1);
+
+    QCheckBox* show_lan = new QCheckBox(tr("Show LAN servers"));
+    filter_widget_layout->addWidget(show_lan, 0, 1);
+
+    not_full = new QCheckBox(tr("Hide full"));
+    filter_widget_layout->addWidget(not_full, 0, 1);
+
+    not_empty = new QCheckBox("Hide empty");
+    filter_widget_layout->addWidget(not_empty, 1, 1);
+
+    QLabel* ping_filter_label = new QLabel(tr("Ping"));
+    pingFilter = new QSpinBox();
+    unsigned int maximumPing = 9999;
+    pingFilter->setRange(0, maximumPing);
+    pingFilter->setValue(maximumPing);
+    pingFilter->show();
+    filter_widget_layout->addWidget(ping_filter_label, 2, 1);
+    filter_widget_layout->addWidget(pingFilter, 2, 1);
+
+    centralWidgetLayout->addWidget(filter_widget);
+    setCentralWidget(centralWidget);    
+
+#if 1
+    // Create status bar
+    emu_speed_label = new QLabel();
+    emu_speed_label->setToolTip(tr("Current emulation speed. Values higher or lower than 100% "
+                                   "indicate emulation is running faster or slower than a 3DS."));
+    game_fps_label = new QLabel();
+    game_fps_label->setToolTip(tr("How many frames per second the game is currently displaying. "
+                                  "This will vary from game to game and scene to scene."));
+    emu_frametime_label = new QLabel();
+    emu_frametime_label->setToolTip(
+        tr("Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For "
+           "full-speed emulation this should be at most 16.67 ms."));
+
+    for (auto& label : {emu_speed_label, game_fps_label, emu_frametime_label}) {
+        label->setVisible(false);
+        label->setFrameStyle(QFrame::NoFrame);
+        label->setContentsMargins(4, 0, 4, 0);
+        statusBar()->addPermanentWidget(label);
+    }
+    statusBar()->setVisible(true);
+
+
+
+emu_speed_label->setText(tr("5 servers found, 3 hidden / filtered."));
+
+#endif
+}
+
+#if 0
+void RoomListWindow::InitializeDebugWidgets() {
+#if 0
+    connect(ui.action_Create_Pica_Surface_Viewer, &QAction::triggered, this,
+            &RoomListWindow::OnCreateGraphicsSurfaceViewer);
+
+    QMenu* debug_menu = ui.menu_View_Debugging;
+
+#if MICROPROFILE_ENABLED
+    microProfileDialog = new MicroProfileDialog(this);
+    microProfileDialog->hide();
+    debug_menu->addAction(microProfileDialog->toggleViewAction());
+#endif
+
+    disasmWidget = new DisassemblerWidget(this, emu_thread.get());
+    addDockWidget(Qt::BottomDockWidgetArea, disasmWidget);
+    disasmWidget->hide();
+    debug_menu->addAction(disasmWidget->toggleViewAction());
+    connect(this, &RoomListWindow::EmulationStarting, disasmWidget,
+            &DisassemblerWidget::OnEmulationStarting);
+    connect(this, &RoomListWindow::EmulationStopping, disasmWidget,
+            &DisassemblerWidget::OnEmulationStopping);
+
+    registersWidget = new RegistersWidget(this);
+    addDockWidget(Qt::RightDockWidgetArea, registersWidget);
+    registersWidget->hide();
+    debug_menu->addAction(registersWidget->toggleViewAction());
+    connect(this, &RoomListWindow::EmulationStarting, registersWidget,
+            &RegistersWidget::OnEmulationStarting);
+    connect(this, &RoomListWindow::EmulationStopping, registersWidget,
+            &RegistersWidget::OnEmulationStopping);
+
+    callstackWidget = new CallstackWidget(this);
+    addDockWidget(Qt::RightDockWidgetArea, callstackWidget);
+    callstackWidget->hide();
+    debug_menu->addAction(callstackWidget->toggleViewAction());
+
+    graphicsWidget = new GPUCommandStreamWidget(this);
+    addDockWidget(Qt::RightDockWidgetArea, graphicsWidget);
+    graphicsWidget->hide();
+    debug_menu->addAction(graphicsWidget->toggleViewAction());
+
+    graphicsCommandsWidget = new GPUCommandListWidget(this);
+    addDockWidget(Qt::RightDockWidgetArea, graphicsCommandsWidget);
+    graphicsCommandsWidget->hide();
+    debug_menu->addAction(graphicsCommandsWidget->toggleViewAction());
+
+    graphicsBreakpointsWidget = new GraphicsBreakPointsWidget(Pica::g_debug_context, this);
+    addDockWidget(Qt::RightDockWidgetArea, graphicsBreakpointsWidget);
+    graphicsBreakpointsWidget->hide();
+    debug_menu->addAction(graphicsBreakpointsWidget->toggleViewAction());
+
+    graphicsVertexShaderWidget = new GraphicsVertexShaderWidget(Pica::g_debug_context, this);
+    addDockWidget(Qt::RightDockWidgetArea, graphicsVertexShaderWidget);
+    graphicsVertexShaderWidget->hide();
+    debug_menu->addAction(graphicsVertexShaderWidget->toggleViewAction());
+
+    graphicsTracingWidget = new GraphicsTracingWidget(Pica::g_debug_context, this);
+    addDockWidget(Qt::RightDockWidgetArea, graphicsTracingWidget);
+    graphicsTracingWidget->hide();
+    debug_menu->addAction(graphicsTracingWidget->toggleViewAction());
+    connect(this, &RoomListWindow::EmulationStarting, graphicsTracingWidget,
+            &GraphicsTracingWidget::OnEmulationStarting);
+    connect(this, &RoomListWindow::EmulationStopping, graphicsTracingWidget,
+            &GraphicsTracingWidget::OnEmulationStopping);
+
+    waitTreeWidget = new WaitTreeWidget(this);
+    addDockWidget(Qt::LeftDockWidgetArea, waitTreeWidget);
+    waitTreeWidget->hide();
+    debug_menu->addAction(waitTreeWidget->toggleViewAction());
+    connect(this, &RoomListWindow::EmulationStarting, waitTreeWidget,
+            &WaitTreeWidget::OnEmulationStarting);
+    connect(this, &RoomListWindow::EmulationStopping, waitTreeWidget,
+            &WaitTreeWidget::OnEmulationStopping);
+#endif
+}
+
+void RoomListWindow::InitializeRecentFileMenuActions() {
+#if 0
+    for (int i = 0; i < max_recent_files_item; ++i) {
+        actions_recent_files[i] = new QAction(this);
+        actions_recent_files[i]->setVisible(false);
+        connect(actions_recent_files[i], SIGNAL(triggered()), this, SLOT(OnMenuRecentFile()));
+
+        ui.menu_recent_files->addAction(actions_recent_files[i]);
+    }
+
+    UpdateRecentFiles();
+#endif
+}
+
+void RoomListWindow::InitializeHotkeys() {
+#if 0
+    RegisterHotkey("Main Window", "Load File", QKeySequence::Open);
+    RegisterHotkey("Main Window", "Swap Screens", QKeySequence::NextChild);
+    RegisterHotkey("Main Window", "Start Emulation");
+    LoadHotkeys();
+
+    connect(GetHotkey("Main Window", "Load File", this), SIGNAL(activated()), this,
+            SLOT(OnMenuLoadFile()));
+    connect(GetHotkey("Main Window", "Start Emulation", this), SIGNAL(activated()), this,
+            SLOT(OnStartGame()));
+    connect(GetHotkey("Main Window", "Swap Screens", render_window), SIGNAL(activated()), this,
+            SLOT(OnSwapScreens()));
+#endif
+}
+
+#endif
+
+void RoomListWindow::SetDefaultUIGeometry() {
+#if 0
+    // geometry: 55% of the window contents are in the upper screen half, 45% in the lower half
+    const QRect screenRect = QApplication::desktop()->screenGeometry(this);
+
+    const int w = screenRect.width() * 2 / 3;
+    const int h = screenRect.height() / 2;
+    const int x = (screenRect.x() + screenRect.width()) / 2 - w / 2;
+    const int y = (screenRect.y() + screenRect.height()) / 2 - h * 55 / 100;
+
+    setGeometry(x, y, w, h);
+#endif
+}
+
+
+void RoomListWindow::ConnectWidgetEvents() {
+#if 0
+    connect(room_list, SIGNAL(GameChosen(QString)), this, SLOT(OnRoomListLoadFile(QString)));
+    connect(room_list, SIGNAL(OpenSaveFolderRequested(u64)), this,
+            SLOT(OnRoomListOpenSaveFolder(u64)));
+
+    connect(this, SIGNAL(EmulationStarting(EmuThread*)), render_window,
+            SLOT(OnEmulationStarting(EmuThread*)));
+    connect(this, SIGNAL(EmulationStopping()), render_window, SLOT(OnEmulationStopping()));
+
+    connect(&status_bar_update_timer, &QTimer::timeout, this, &RoomListWindow::UpdateStatusBar);
+#endif
+}
+
+
+
+void RoomListWindow::UpdateStatusBar() {
+#if 0
+    if (emu_thread == nullptr) {
+        status_bar_update_timer.stop();
+        return;
+    }
+
+    auto results = Core::System::GetInstance().GetAndResetPerfStats();
+
+    emu_speed_label->setText(tr("Speed: %1%").arg(results.emulation_speed * 100.0, 0, 'f', 0));
+    game_fps_label->setText(tr("Game: %1 FPS").arg(results.game_fps, 0, 'f', 0));
+    emu_frametime_label->setText(tr("Frame: %1 ms").arg(results.frametime * 1000.0, 0, 'f', 2));
+
+    emu_speed_label->setVisible(true);
+    game_fps_label->setVisible(true);
+    emu_frametime_label->setVisible(true);
+#endif
+}
+
+bool RoomListWindow::ConfirmClose() {
+    auto answer = QMessageBox::question(
+        this, tr("Citra"),
+        tr("Are you sure you want to leave this room? All other members will loose connection to you."),
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+    return answer != QMessageBox::No;
+}
+
+void RoomListWindow::closeEvent(QCloseEvent* event) {
+#if 0
+    if (!ConfirmClose()) {
+        event->ignore();
+        return;
+    }
+
+    UISettings::values.geometry = saveGeometry();
+    UISettings::values.state = saveState();
+    UISettings::values.renderwindow_geometry = render_window->saveGeometry();
+#if MICROPROFILE_ENABLED
+    UISettings::values.microprofile_geometry = microProfileDialog->saveGeometry();
+    UISettings::values.microprofile_visible = microProfileDialog->isVisible();
+#endif
+    UISettings::values.single_window_mode = ui.action_Single_Window_Mode->isChecked();
+    UISettings::values.display_titlebar = ui.action_Display_Dock_Widget_Headers->isChecked();
+    UISettings::values.show_status_bar = ui.action_Show_Status_Bar->isChecked();
+    UISettings::values.first_start = false;
+
+    room_list->SaveInterfaceLayout();
+    SaveHotkeys();
+
+    // Shutdown session if the emu thread is active...
+    if (emu_thread != nullptr)
+        ShutdownGame();
+
+    render_window->close();
+
+    QWidget::closeEvent(event);
+#endif
+}
+

--- a/src/frontend/room_list_window.cpp
+++ b/src/frontend/room_list_window.cpp
@@ -101,7 +101,7 @@ void RoomListWindow::InitializeWidgets() {
     for (unsigned i = 0; i < 10; i++) {
         QList<QStandardItem*> l;
         for(unsigned int j = 0; j < 5; j++) {
-		        QStandardItem *child = new QStandardItem( QString("Item %0").arg(i)); //, QString("Foo"));
+		        QStandardItem *child = new QStandardItem(QString("Item %0").arg(i));
 		        child->setEditable( false );
             l.append(child);
         }

--- a/src/frontend/room_list_window.cpp
+++ b/src/frontend/room_list_window.cpp
@@ -33,8 +33,8 @@ RoomListWindow::RoomListWindow() {
     RestoreUIState();
 
     ConnectMenuEvents();
-    ConnectWidgetEvents();
 #endif
+    ConnectWidgetEvents();
 
     setWindowTitle(QString("Room List"));
     show();
@@ -70,12 +70,12 @@ void RoomListWindow::InitializeWidgets() {
     direct_connection_widget->setLayout(direct_connection_widget_layout);
     {
         QLabel* server_label = new QLabel(tr("Server"));
-        QLineEdit* server = new QLineEdit();
+        server = new QLineEdit();
         direct_connection_widget_layout->addWidget(server_label);
         direct_connection_widget_layout->addWidget(server);
 
         QLabel* port_label = new QLabel(tr("Port"));
-        QSpinBox* port = new QSpinBox();
+        port = new QSpinBox();
         port->setRange(1, 65535);
         port->setValue(1234); // FIXME: Pick a proper port and / or retrieve it from tunnler
         direct_connection_widget_layout->addWidget(port_label);
@@ -147,7 +147,7 @@ void RoomListWindow::InitializeWidgets() {
            "full-speed emulation this should be at most 16.67 ms."));
 
     for (auto& label : {emu_speed_label, game_fps_label, emu_frametime_label}) {
-        label->setVisible(false);
+        //label->setVisible(false);
         label->setFrameStyle(QFrame::NoFrame);
         label->setContentsMargins(4, 0, 4, 0);
         statusBar()->addPermanentWidget(label);
@@ -159,6 +159,19 @@ void RoomListWindow::InitializeWidgets() {
 emu_speed_label->setText(tr("5 servers found, 3 hidden / filtered."));
 
 #endif
+
+
+    for (unsigned i = 0; i < 10; i++) {
+        QList<QStandardItem*> l;
+        for(unsigned int j = 0; j < 5; j++) {
+		        QStandardItem *child = new QStandardItem( QString("Item %0").arg(i)); //, QString("Foo"));
+		        child->setEditable( false );
+            l.append(child);
+        }
+        room_list->AddEntry(l);
+    }
+
+
 }
 
 #if 0
@@ -285,9 +298,19 @@ void RoomListWindow::SetDefaultUIGeometry() {
 }
 
 
+void RoomListWindow::OnRoomListSelectRoom(QString server, u16 serverPort, bool join) {
+  this->server->setText(server);
+  this->port->setValue(serverPort);
+
+  if (join) {
+    //FIXME: Pretend we pressed the join button
+    printf("Pretending to press join lolol");
+  }
+}
+
 void RoomListWindow::ConnectWidgetEvents() {
+    connect(room_list, SIGNAL(RoomChosen(QString, u16, bool)), this, SLOT(OnRoomListSelectRoom(QString, u16, bool)));
 #if 0
-    connect(room_list, SIGNAL(GameChosen(QString)), this, SLOT(OnRoomListLoadFile(QString)));
     connect(room_list, SIGNAL(OpenSaveFolderRequested(u64)), this,
             SLOT(OnRoomListOpenSaveFolder(u64)));
 

--- a/src/frontend/room_list_window.cpp
+++ b/src/frontend/room_list_window.cpp
@@ -169,11 +169,12 @@ void RoomListWindow::InitializeWidgets() {
         label->setContentsMargins(4, 0, 4, 0);
         statusBar()->addPermanentWidget(label);
     }
-    statusBar()->setVisible(true);
+    statusBar()->setVisible(false);
 
 
-
-emu_speed_label->setText(tr("5 servers found, 3 hidden / filtered."));
+unsigned int servers_found = 0;
+unsigned int servers_filtered = 0;
+emu_speed_label->setText(tr("%1 servers found, %2 hidden / filtered.").arg(servers_found).arg(servers_filtered));
 
 #endif
 

--- a/src/frontend/room_list_window.h
+++ b/src/frontend/room_list_window.h
@@ -2,7 +2,9 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#define u64 uint64_t
+#include <cstdint>
+typedef uint16_t u16;
+typedef uint64_t u64;
 
 #ifndef _CITRA_QT_ROOM_LIST_WINDOW_HXX_
 #define _CITRA_QT_ROOM_LIST_WINDOW_HXX_
@@ -45,12 +47,12 @@ private:
     void closeEvent(QCloseEvent* event) override;
 
 private slots:
+    void OnRoomListSelectRoom(QString server, u16 serverPort, bool join);
 #if 0
     void OnStartGame();
     void OnPauseGame();
     void OnStopGame();
     /// Called whenever a user selects a game in the game list widget.
-    void OnGameListLoadFile(QString game_path);
     void OnGameListOpenSaveFolder(u64 program_id);
     void OnMenuLoadFile();
     void OnMenuLoadSymbolMap();
@@ -73,6 +75,9 @@ private:
     GRenderWindow* render_window;
 */
     RoomList* room_list;
+
+    QLineEdit* server = nullptr;
+    QSpinBox* port = nullptr;
 
     QCheckBox* not_full = nullptr;
     QCheckBox* not_empty = nullptr;

--- a/src/frontend/room_list_window.h
+++ b/src/frontend/room_list_window.h
@@ -1,0 +1,114 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#define u64 uint64_t
+
+#ifndef _CITRA_QT_ROOM_LIST_WINDOW_HXX_
+#define _CITRA_QT_ROOM_LIST_WINDOW_HXX_
+
+#include <memory>
+#include <QMainWindow>
+#include <QLabel>
+#include <QTimer>
+#include <QCheckBox>
+#include <QLineEdit>
+#include <QSpinBox>
+
+class RoomList;
+
+class RoomListWindow : public QMainWindow {
+    Q_OBJECT
+
+    typedef uint8_t EmuThread;
+
+    /// Max number of recently loaded items to keep track of
+    static const int max_recent_files_item = 10;
+
+public:
+    RoomListWindow();
+    ~RoomListWindow();
+
+private:
+    void InitializeWidgets();
+
+    void SetDefaultUIGeometry();
+
+    void ConnectWidgetEvents();
+
+    /**
+     * Ask the user if they really want to leave a room / close the window.
+     *
+     * @return true if the user confirmed
+     */
+    bool ConfirmClose();
+    void closeEvent(QCloseEvent* event) override;
+
+private slots:
+#if 0
+    void OnStartGame();
+    void OnPauseGame();
+    void OnStopGame();
+    /// Called whenever a user selects a game in the game list widget.
+    void OnGameListLoadFile(QString game_path);
+    void OnGameListOpenSaveFolder(u64 program_id);
+    void OnMenuLoadFile();
+    void OnMenuLoadSymbolMap();
+    /// Called whenever a user selects the "File->Select Game List Root" menu item
+    void OnMenuSelectGameListRoot();
+    void OnMenuRecentFile();
+    void OnSwapScreens();
+    void OnConfigure();
+    void OnDisplayTitleBars(bool);
+    void ToggleWindowMode();
+    void OnCreateGraphicsSurfaceViewer();
+#endif
+
+private:
+    void UpdateStatusBar();
+
+    //Ui::MainWindow ui;
+
+/*
+    GRenderWindow* render_window;
+*/
+    RoomList* room_list;
+
+    QCheckBox* not_full = nullptr;
+    QCheckBox* not_empty = nullptr;
+//FIXME: Var naming for these 3..
+    QLineEdit* gameFilter = nullptr;
+    QLineEdit* nameFilter = nullptr;
+    QSpinBox* pingFilter = nullptr;
+
+    // Status bar elements
+    QLabel* emu_speed_label = nullptr;
+    QLabel* game_fps_label = nullptr;
+    QLabel* emu_frametime_label = nullptr;
+    QTimer status_bar_update_timer;
+
+#if 0
+    std::unique_ptr<Config> config;
+
+    // Whether emulation is currently running in Citra.
+    bool emulation_running = false;
+    std::unique_ptr<EmuThread> emu_thread;
+
+    // Debugger panes
+    ProfilerWidget* profilerWidget;
+    MicroProfileDialog* microProfileDialog;
+    DisassemblerWidget* disasmWidget;
+    RegistersWidget* registersWidget;
+    CallstackWidget* callstackWidget;
+    GPUCommandStreamWidget* graphicsWidget;
+    GPUCommandListWidget* graphicsCommandsWidget;
+    GraphicsBreakPointsWidget* graphicsBreakpointsWidget;
+    GraphicsVertexShaderWidget* graphicsVertexShaderWidget;
+    GraphicsTracingWidget* graphicsTracingWidget;
+    WaitTreeWidget* waitTreeWidget;
+
+    QAction* actions_recent_files[max_recent_files_item];
+#endif
+};
+
+#endif // _CITRA_QT_ROOM_LIST_WINDOW_HXX_

--- a/src/frontend/room_view_window.cpp
+++ b/src/frontend/room_view_window.cpp
@@ -467,11 +467,21 @@ void RoomViewWindow::ToggleWindowMode() {
 
 static void appendHtml(QTextEdit* text_edit, QString html) {
     //FIXME: Keep cursor / selection where it is etc
-    //FIXME: If scrollbar was at very bottom, move it to very bottom
-    //FIXME: If scrollbar was not at very bottom, keep it where it is
+
+    auto* scrollbar = text_edit->verticalScrollBar();
+    auto scrollbar_value = scrollbar->value();
+    bool scroll_down = (scrollbar_value == scrollbar->maximum());
+
     QString new_html = text_edit->toHtml();
     new_html += html;
     text_edit->setHtml(new_html);
+
+    // Scroll to the very bottom
+    if (scroll_down) {
+      scrollbar->setValue(scrollbar->maximum());
+    } else {
+      scrollbar->setValue(scrollbar_value);
+    }
 }
 
 void RoomViewWindow::AddRoomMessage(QString message) {
@@ -548,11 +558,11 @@ void RoomViewWindow::OnStateChange() {
 }
 
 void RoomViewWindow::OnRoomGameChange(std::string game_name) {
-    AddRoomMessage(QString(tr("The room is now intended for playing %1")).arg(QString::fromStdString(game_name)));
+    AddRoomMessage(QString(tr("The room is intended for playing %1")).arg(QString::fromStdString(game_name)));
 }
 
 void RoomViewWindow::OnMemberGameChange(std::string nickname, std::string game_name) {
-    AddRoomMessage(QString(tr("%1 is now playing %2")).arg(QString::fromStdString(nickname)).arg(QString::fromStdString(game_name)));
+    AddRoomMessage(QString(tr("%1 is playing %2")).arg(QString::fromStdString(nickname)).arg(QString::fromStdString(game_name)));
 }
 
 void RoomViewWindow::OnDisconnected() {
@@ -560,7 +570,8 @@ void RoomViewWindow::OnDisconnected() {
 }
 
 void RoomViewWindow::OnMemberLeft(std::string nickname) {
-    AddRoomMessage(QString(tr("%1 left the room")).arg(QString::fromStdString(nickname)));
+    QString reason(tr("Unknown reason"));
+    AddRoomMessage(QString(tr("%1 is no longer in the room (%2)")).arg(QString::fromStdString(nickname)).arg(reason));
 }
 
 void RoomViewWindow::OnMemberJoined(std::string nickname) {

--- a/src/frontend/room_view_window.cpp
+++ b/src/frontend/room_view_window.cpp
@@ -12,6 +12,7 @@
 #include <QMessageBox>
 #include <QtGui>
 #include <QtWidgets>
+#include <QSplitter>
 #include <QStandardItemModel>
 #include "room_view_window.h"
 
@@ -32,8 +33,8 @@ RoomViewWindow::RoomViewWindow() {
     RestoreUIState();
 
     ConnectMenuEvents();
-    ConnectWidgetEvents();
 #endif
+    ConnectWidgetEvents();
 
     setWindowTitle(QString("Room"));
     show();
@@ -66,68 +67,80 @@ void RoomViewWindow::InitializeWidgets() {
 #endif
 
 
-centralwidget = new QWidget();
-verticalLayout = new QVBoxLayout();
-centralwidget->setLayout(verticalLayout);
+    centralwidget = new QWidget();
+    verticalLayout = new QVBoxLayout();
+    centralwidget->setLayout(verticalLayout);
 
-//FIXME: !!!! Either make this a headline or move it into the status bar
-QLabel* room_name_label = new QLabel();
-room_name_label->setText("Tunnler Battlefield");
-verticalLayout->addWidget(room_name_label);
-
-
-chatWidget = new QWidget();
-gridLayout = new QGridLayout();
-chatWidget->setLayout(gridLayout);
-
-chatLog = new QTextEdit();
-chatLog->setReadOnly(true);
-gridLayout->addWidget(chatLog, 0, 0);
-
-QStandardItemModel* item_model = nullptr;
-memberList = new QTreeView(); // <item row="0" column="1" colspan="2" >
-item_model = new QStandardItemModel(memberList);
-memberList->setModel(item_model);
-
-memberList->setAlternatingRowColors(true);
-memberList->setSelectionMode(QHeaderView::SingleSelection);
-memberList->setSelectionBehavior(QHeaderView::SelectRows);
-memberList->setVerticalScrollMode(QHeaderView::ScrollPerPixel);
-memberList->setHorizontalScrollMode(QHeaderView::ScrollPerPixel);
-memberList->setSortingEnabled(true);
-memberList->setEditTriggers(QHeaderView::NoEditTriggers);
-memberList->setUniformRowHeights(true);
-memberList->setContextMenuPolicy(Qt::CustomContextMenu);
-
-enum {
-    COLUMN_ACTIVITY,
-    COLUMN_NAME,
-    COLUMN_GAME,
-    // COLUMN_MAC_ADDRESS, // This one would only confuse users
-    COLUMN_PING,
-    COLUMN_COUNT, // Number of columns
-};
-
-item_model->insertColumns(0, COLUMN_COUNT);
-item_model->setHeaderData(COLUMN_ACTIVITY, Qt::Horizontal, "Activity");
-item_model->setHeaderData(COLUMN_NAME, Qt::Horizontal, "Name");
-item_model->setHeaderData(COLUMN_GAME, Qt::Horizontal, "Game");
-//item_model->setHeaderData(COLUMN_MAC_ADDRESS, Qt::Horizontal, "MAC Address");
-item_model->setHeaderData(COLUMN_PING, Qt::Horizontal, "Ping");
+    //FIXME: !!!! Either make this a headline or move it into the status bar
+    QLabel* room_name_label = new QLabel();
+    room_name_label->setText("Tunnler Battlefield");
+    verticalLayout->addWidget(room_name_label);
 
 
-gridLayout->addWidget(memberList, 0, 1);
+    QSplitter* splitter = new QSplitter();
 
-sayLineEdit = new QLineEdit(); // <item row="1" column="0" colspan="2" >           
-gridLayout->addWidget(sayLineEdit, 1, 0);
+    QWidget* splitter_left = new QWidget();
+    QVBoxLayout* splitter_left_layout = new QVBoxLayout();
+    splitter_left->setLayout(splitter_left_layout);
+    splitter->insertWidget(0, splitter_left);
 
-sayButton = new QPushButton(tr("Say")); // <item row="1" column="2" >
-sayButton->show();
-gridLayout->addWidget(sayButton, 1, 1);
+    QWidget* splitter_right = new QWidget();
+    QVBoxLayout* splitter_right_layout = new QVBoxLayout();
+    splitter_right->setLayout(splitter_right_layout);
+    splitter->insertWidget(1, splitter_right);
 
-verticalLayout->addWidget(chatWidget);
+    chatWidget = new QWidget();
+    gridLayout = new QGridLayout();
+    chatWidget->setLayout(gridLayout);
 
-setCentralWidget(centralwidget);
+    chatLog = new QTextEdit();
+    chatLog->setReadOnly(true);
+    splitter_left_layout->addWidget(chatLog);
+
+    QStandardItemModel* item_model = nullptr;
+    memberList = new QTreeView(); // <item row="0" column="1" colspan="2" >
+    item_model = new QStandardItemModel(memberList);
+    memberList->setModel(item_model);
+
+    memberList->setAlternatingRowColors(true);
+    memberList->setSelectionMode(QHeaderView::SingleSelection);
+    memberList->setSelectionBehavior(QHeaderView::SelectRows);
+    memberList->setVerticalScrollMode(QHeaderView::ScrollPerPixel);
+    memberList->setHorizontalScrollMode(QHeaderView::ScrollPerPixel);
+    memberList->setSortingEnabled(true);
+    memberList->setEditTriggers(QHeaderView::NoEditTriggers);
+    memberList->setUniformRowHeights(true);
+    memberList->setContextMenuPolicy(Qt::CustomContextMenu);
+
+    enum {
+        COLUMN_ACTIVITY,
+        COLUMN_NAME,
+        COLUMN_GAME,
+        // COLUMN_MAC_ADDRESS, // This one would only confuse users
+        COLUMN_PING,
+        COLUMN_COUNT, // Number of columns
+    };
+
+    item_model->insertColumns(0, COLUMN_COUNT);
+    item_model->setHeaderData(COLUMN_ACTIVITY, Qt::Horizontal, "Activity");
+    item_model->setHeaderData(COLUMN_NAME, Qt::Horizontal, "Name");
+    item_model->setHeaderData(COLUMN_GAME, Qt::Horizontal, "Game");
+    //item_model->setHeaderData(COLUMN_MAC_ADDRESS, Qt::Horizontal, "MAC Address");
+    item_model->setHeaderData(COLUMN_PING, Qt::Horizontal, "Ping");
+
+
+    splitter_right_layout->addWidget(memberList);
+
+    sayLineEdit = new QLineEdit(); // <item row="1" column="0" colspan="2" >           
+    splitter_left_layout->addWidget(sayLineEdit);
+
+    sayButton = new QPushButton(tr("Say")); // <item row="1" column="2" >
+    sayButton->show();
+    splitter_right_layout->addWidget(sayButton);
+
+    verticalLayout->addWidget(splitter);
+
+    setCentralWidget(centralwidget);
 
 #if 1
     // Create status bar
@@ -151,35 +164,42 @@ setCentralWidget(centralwidget);
     statusBar()->setVisible(true);
 
 
-emu_speed_label->setText("Connected to 127.0.0.1");
-emu_speed_label->show();
+    emu_speed_label->setText("Connected to 127.0.0.1");
+    emu_speed_label->show();
 
 #endif
 
 
 
 
-// Some testing
-QString html;
+    // Some testing
+    QString html;
 
-std::vector<std::string> chatMessages;
+    std::vector<std::string> chatMessages;
 
-chatMessages.emplace_back("JayFoxRox: Heyho");
-chatMessages.emplace_back("JayFoxRox: meep <b>meep</b>");
+#if 0
+    html += "<font color=\"gray\"><i>" + QString(tr("Connecting..")).toHtmlEscaped() + "</i></font><br>";
+    html += "<font color=\"gray\"><i>" + QString(tr("Connected")).toHtmlEscaped() + "</i></font><br>";
+#else
+    html += "<font color=\"green\"><b>" + QString(tr("Connecting..")).toHtmlEscaped() + "</b></font><br>";
+    html += "<font color=\"green\"><b>" + QString(tr("Connected")).toHtmlEscaped() + "</b></font><br>";
+#endif
 
-for(const auto& message : chatMessages) {
-  //FIXME: We should probably adopt the established pidgin color scheme where:
-  //- either every user has a different color and you appear bold and always in some navy blue
-  //- OR you are navy blue and everyone else is read [all names bold]
-  // This would allow to faster recognize who said something last / if there have been new messages
-  html += QString::fromStdString(message).toHtmlEscaped() + "<br>";
-}
-html += "<font color=\"gray\"><i>" + QString(tr("XYZ joined the room")).toHtmlEscaped() + "</i></font><br>";
-html += "<font color=\"gray\"><i>" + QString(tr("XYZ changed their game")).toHtmlEscaped() + "</i></font><br>";
-html += "<font color=\"gray\"><i>" + QString(tr("XYZ left the room")).toHtmlEscaped() + "</i></font><br>";
-html += "<font color=\"green\"><b>" + QString(tr("You were dropped from the room (Connection lost)")).toHtmlEscaped() + "</b></font><br>";
-html += "<font color=\"blue\">" + QString(tr("RakNet debug message?!")).toHtmlEscaped() + "</font><br>";
-chatLog->setHtml(html);
+    chatMessages.emplace_back("JayFoxRox: Heyho");
+    chatMessages.emplace_back("JayFoxRox: meep <b>meep</b>");
+    for(const auto& message : chatMessages) {
+        //FIXME: We should probably adopt the established pidgin color scheme where:
+        //- either every user has a different color and you appear bold and always in some navy blue
+        //- OR you are navy blue and everyone else is read [all names bold]
+        // This would allow to faster recognize who said something last / if there have been new messages
+        html += QString::fromStdString(message).toHtmlEscaped() + "<br>";
+    }
+    html += "<font color=\"gray\"><i>" + QString(tr("XYZ joined the room")).toHtmlEscaped() + "</i></font><br>";
+    html += "<font color=\"gray\"><i>" + QString(tr("XYZ changed their game")).toHtmlEscaped() + "</i></font><br>";
+    html += "<font color=\"gray\"><i>" + QString(tr("XYZ left the room")).toHtmlEscaped() + "</i></font><br>";
+    html += "<font color=\"green\"><b>" + QString(tr("You were dropped from the room (Connection lost)")).toHtmlEscaped() + "</b></font><br>";
+    html += "<font color=\"blue\">" + QString(tr("RakNet debug message?!")).toHtmlEscaped() + "</font><br>";
+    chatLog->setHtml(html);
 
 
 }
@@ -327,8 +347,19 @@ void RoomViewWindow::RestoreUIState() {
     statusBar()->setVisible(ui.action_Show_Status_Bar->isChecked());
 #endif
 }
+#endif
+
+void RoomViewWindow::OnSay() {
+    room_member.SendChatMessage(sayLineEdit->text().toStdString());
+    sayLineEdit->setText("");
+}
 
 void RoomViewWindow::ConnectWidgetEvents() {
+
+
+    connect(sayLineEdit, SIGNAL(returnPressed()), sayButton, SIGNAL(clicked()));
+    connect(sayButton, SIGNAL(clicked()), this, SLOT(OnSay()));
+
 #if 0
     connect(game_list, SIGNAL(GameChosen(QString)), this, SLOT(OnGameListLoadFile(QString)));
     connect(game_list, SIGNAL(OpenSaveFolderRequested(u64)), this,
@@ -342,6 +373,7 @@ void RoomViewWindow::ConnectWidgetEvents() {
 #endif
 }
 
+#if 0
 void RoomViewWindow::ConnectMenuEvents() {
 #if 0
     // File
@@ -574,17 +606,17 @@ void RoomViewWindow::UpdateStatusBar() {
 bool RoomViewWindow::ConfirmClose() {
     auto answer = QMessageBox::question(
         this, tr("Citra"),
-        tr("Are you sure you want to leave this room? All other members will loose connection to you."),
+        tr("Are you sure you want to leave this room? Your simulated WiFi connection to all other members will be lost."),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
     return answer != QMessageBox::No;
 }
 
 void RoomViewWindow::closeEvent(QCloseEvent* event) {
-#if 0
     if (!ConfirmClose()) {
         event->ignore();
         return;
     }
+#if 0
 
     UISettings::values.geometry = saveGeometry();
     UISettings::values.state = saveState();

--- a/src/frontend/room_view_window.cpp
+++ b/src/frontend/room_view_window.cpp
@@ -1,0 +1,612 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <cinttypes>
+#include <clocale>
+#include <memory>
+#include <thread>
+#define QT_NO_OPENGL
+#include <QDesktopWidget>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QtGui>
+#include <QtWidgets>
+#include <QStandardItemModel>
+#include "room_view_window.h"
+
+RoomViewWindow::RoomViewWindow() {
+#if 0
+    setAcceptDrops(true);
+    ui.setupUi(this);
+    statusBar()->hide();
+#endif
+
+    InitializeWidgets();
+#if 0
+    InitializeDebugWidgets();
+    InitializeRecentFileMenuActions();
+    InitializeHotkeys();
+
+    SetDefaultUIGeometry();
+    RestoreUIState();
+
+    ConnectMenuEvents();
+    ConnectWidgetEvents();
+#endif
+
+    setWindowTitle(QString("Room"));
+    show();
+
+#if 0
+    game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
+
+    QStringList args = QApplication::arguments();
+    if (args.length() >= 2) {
+        BootGame(args[1]);
+    }
+#endif
+}
+
+RoomViewWindow::~RoomViewWindow() {
+#if 0
+    // will get automatically deleted otherwise
+    if (render_window->parent() == nullptr)
+        delete render_window;
+
+    Pica::g_debug_context.reset();
+#endif
+}
+
+void RoomViewWindow::InitializeWidgets() {
+#if 0
+    game_list = new GameList();
+    setCentralWidget(game_list);    
+//    ui.horizontalLayout->addWidget(game_list);
+#endif
+
+
+centralwidget = new QWidget();
+verticalLayout = new QVBoxLayout();
+centralwidget->setLayout(verticalLayout);
+
+//FIXME: !!!! Either make this a headline or move it into the status bar
+QLabel* room_name_label = new QLabel();
+room_name_label->setText("Tunnler Battlefield");
+verticalLayout->addWidget(room_name_label);
+
+
+chatWidget = new QWidget();
+gridLayout = new QGridLayout();
+chatWidget->setLayout(gridLayout);
+
+chatLog = new QTextEdit();
+chatLog->setReadOnly(true);
+gridLayout->addWidget(chatLog, 0, 0);
+
+QStandardItemModel* item_model = nullptr;
+memberList = new QTreeView(); // <item row="0" column="1" colspan="2" >
+item_model = new QStandardItemModel(memberList);
+memberList->setModel(item_model);
+
+memberList->setAlternatingRowColors(true);
+memberList->setSelectionMode(QHeaderView::SingleSelection);
+memberList->setSelectionBehavior(QHeaderView::SelectRows);
+memberList->setVerticalScrollMode(QHeaderView::ScrollPerPixel);
+memberList->setHorizontalScrollMode(QHeaderView::ScrollPerPixel);
+memberList->setSortingEnabled(true);
+memberList->setEditTriggers(QHeaderView::NoEditTriggers);
+memberList->setUniformRowHeights(true);
+memberList->setContextMenuPolicy(Qt::CustomContextMenu);
+
+enum {
+    COLUMN_ACTIVITY,
+    COLUMN_NAME,
+    COLUMN_GAME,
+    // COLUMN_MAC_ADDRESS, // This one would only confuse users
+    COLUMN_PING,
+    COLUMN_COUNT, // Number of columns
+};
+
+item_model->insertColumns(0, COLUMN_COUNT);
+item_model->setHeaderData(COLUMN_ACTIVITY, Qt::Horizontal, "Activity");
+item_model->setHeaderData(COLUMN_NAME, Qt::Horizontal, "Name");
+item_model->setHeaderData(COLUMN_GAME, Qt::Horizontal, "Game");
+//item_model->setHeaderData(COLUMN_MAC_ADDRESS, Qt::Horizontal, "MAC Address");
+item_model->setHeaderData(COLUMN_PING, Qt::Horizontal, "Ping");
+
+
+gridLayout->addWidget(memberList, 0, 1);
+
+sayLineEdit = new QLineEdit(); // <item row="1" column="0" colspan="2" >           
+gridLayout->addWidget(sayLineEdit, 1, 0);
+
+sayButton = new QPushButton(tr("Say")); // <item row="1" column="2" >
+sayButton->show();
+gridLayout->addWidget(sayButton, 1, 1);
+
+verticalLayout->addWidget(chatWidget);
+
+setCentralWidget(centralwidget);
+
+#if 1
+    // Create status bar
+    emu_speed_label = new QLabel();
+    emu_speed_label->setToolTip(tr("Current emulation speed. Values higher or lower than 100% "
+                                   "indicate emulation is running faster or slower than a 3DS."));
+    game_fps_label = new QLabel();
+    game_fps_label->setToolTip(tr("How many frames per second the game is currently displaying. "
+                                  "This will vary from game to game and scene to scene."));
+    emu_frametime_label = new QLabel();
+    emu_frametime_label->setToolTip(
+        tr("Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For "
+           "full-speed emulation this should be at most 16.67 ms."));
+
+    for (auto& label : {emu_speed_label, game_fps_label, emu_frametime_label}) {
+        label->setVisible(false);
+        label->setFrameStyle(QFrame::NoFrame);
+        label->setContentsMargins(4, 0, 4, 0);
+        statusBar()->addPermanentWidget(label);
+    }
+    statusBar()->setVisible(true);
+
+
+emu_speed_label->setText("Connected to 127.0.0.1");
+emu_speed_label->show();
+
+#endif
+
+
+
+
+// Some testing
+QString html;
+
+std::vector<std::string> chatMessages;
+
+chatMessages.emplace_back("JayFoxRox: Heyho");
+chatMessages.emplace_back("JayFoxRox: meep <b>meep</b>");
+
+for(const auto& message : chatMessages) {
+  //FIXME: We should probably adopt the established pidgin color scheme where:
+  //- either every user has a different color and you appear bold and always in some navy blue
+  //- OR you are navy blue and everyone else is read [all names bold]
+  // This would allow to faster recognize who said something last / if there have been new messages
+  html += QString::fromStdString(message).toHtmlEscaped() + "<br>";
+}
+html += "<font color=\"gray\"><i>" + QString(tr("XYZ joined the room")).toHtmlEscaped() + "</i></font><br>";
+html += "<font color=\"gray\"><i>" + QString(tr("XYZ changed their game")).toHtmlEscaped() + "</i></font><br>";
+html += "<font color=\"gray\"><i>" + QString(tr("XYZ left the room")).toHtmlEscaped() + "</i></font><br>";
+html += "<font color=\"green\"><b>" + QString(tr("You were dropped from the room (Connection lost)")).toHtmlEscaped() + "</b></font><br>";
+html += "<font color=\"blue\">" + QString(tr("RakNet debug message?!")).toHtmlEscaped() + "</font><br>";
+chatLog->setHtml(html);
+
+
+}
+
+#if 0
+void RoomViewWindow::InitializeDebugWidgets() {
+#if 0
+    connect(ui.action_Create_Pica_Surface_Viewer, &QAction::triggered, this,
+            &RoomViewWindow::OnCreateGraphicsSurfaceViewer);
+
+    QMenu* debug_menu = ui.menu_View_Debugging;
+
+#if MICROPROFILE_ENABLED
+    microProfileDialog = new MicroProfileDialog(this);
+    microProfileDialog->hide();
+    debug_menu->addAction(microProfileDialog->toggleViewAction());
+#endif
+
+    disasmWidget = new DisassemblerWidget(this, emu_thread.get());
+    addDockWidget(Qt::BottomDockWidgetArea, disasmWidget);
+    disasmWidget->hide();
+    debug_menu->addAction(disasmWidget->toggleViewAction());
+    connect(this, &RoomViewWindow::EmulationStarting, disasmWidget,
+            &DisassemblerWidget::OnEmulationStarting);
+    connect(this, &RoomViewWindow::EmulationStopping, disasmWidget,
+            &DisassemblerWidget::OnEmulationStopping);
+
+    registersWidget = new RegistersWidget(this);
+    addDockWidget(Qt::RightDockWidgetArea, registersWidget);
+    registersWidget->hide();
+    debug_menu->addAction(registersWidget->toggleViewAction());
+    connect(this, &RoomViewWindow::EmulationStarting, registersWidget,
+            &RegistersWidget::OnEmulationStarting);
+    connect(this, &RoomViewWindow::EmulationStopping, registersWidget,
+            &RegistersWidget::OnEmulationStopping);
+
+    callstackWidget = new CallstackWidget(this);
+    addDockWidget(Qt::RightDockWidgetArea, callstackWidget);
+    callstackWidget->hide();
+    debug_menu->addAction(callstackWidget->toggleViewAction());
+
+    graphicsWidget = new GPUCommandStreamWidget(this);
+    addDockWidget(Qt::RightDockWidgetArea, graphicsWidget);
+    graphicsWidget->hide();
+    debug_menu->addAction(graphicsWidget->toggleViewAction());
+
+    graphicsCommandsWidget = new GPUCommandListWidget(this);
+    addDockWidget(Qt::RightDockWidgetArea, graphicsCommandsWidget);
+    graphicsCommandsWidget->hide();
+    debug_menu->addAction(graphicsCommandsWidget->toggleViewAction());
+
+    graphicsBreakpointsWidget = new GraphicsBreakPointsWidget(Pica::g_debug_context, this);
+    addDockWidget(Qt::RightDockWidgetArea, graphicsBreakpointsWidget);
+    graphicsBreakpointsWidget->hide();
+    debug_menu->addAction(graphicsBreakpointsWidget->toggleViewAction());
+
+    graphicsVertexShaderWidget = new GraphicsVertexShaderWidget(Pica::g_debug_context, this);
+    addDockWidget(Qt::RightDockWidgetArea, graphicsVertexShaderWidget);
+    graphicsVertexShaderWidget->hide();
+    debug_menu->addAction(graphicsVertexShaderWidget->toggleViewAction());
+
+    graphicsTracingWidget = new GraphicsTracingWidget(Pica::g_debug_context, this);
+    addDockWidget(Qt::RightDockWidgetArea, graphicsTracingWidget);
+    graphicsTracingWidget->hide();
+    debug_menu->addAction(graphicsTracingWidget->toggleViewAction());
+    connect(this, &RoomViewWindow::EmulationStarting, graphicsTracingWidget,
+            &GraphicsTracingWidget::OnEmulationStarting);
+    connect(this, &RoomViewWindow::EmulationStopping, graphicsTracingWidget,
+            &GraphicsTracingWidget::OnEmulationStopping);
+
+    waitTreeWidget = new WaitTreeWidget(this);
+    addDockWidget(Qt::LeftDockWidgetArea, waitTreeWidget);
+    waitTreeWidget->hide();
+    debug_menu->addAction(waitTreeWidget->toggleViewAction());
+    connect(this, &RoomViewWindow::EmulationStarting, waitTreeWidget,
+            &WaitTreeWidget::OnEmulationStarting);
+    connect(this, &RoomViewWindow::EmulationStopping, waitTreeWidget,
+            &WaitTreeWidget::OnEmulationStopping);
+#endif
+}
+
+void RoomViewWindow::InitializeRecentFileMenuActions() {
+#if 0
+    for (int i = 0; i < max_recent_files_item; ++i) {
+        actions_recent_files[i] = new QAction(this);
+        actions_recent_files[i]->setVisible(false);
+        connect(actions_recent_files[i], SIGNAL(triggered()), this, SLOT(OnMenuRecentFile()));
+
+        ui.menu_recent_files->addAction(actions_recent_files[i]);
+    }
+
+    UpdateRecentFiles();
+#endif
+}
+
+void RoomViewWindow::InitializeHotkeys() {
+#if 0
+    RegisterHotkey("Main Window", "Load File", QKeySequence::Open);
+    RegisterHotkey("Main Window", "Swap Screens", QKeySequence::NextChild);
+    RegisterHotkey("Main Window", "Start Emulation");
+    LoadHotkeys();
+
+    connect(GetHotkey("Main Window", "Load File", this), SIGNAL(activated()), this,
+            SLOT(OnMenuLoadFile()));
+    connect(GetHotkey("Main Window", "Start Emulation", this), SIGNAL(activated()), this,
+            SLOT(OnStartGame()));
+    connect(GetHotkey("Main Window", "Swap Screens", render_window), SIGNAL(activated()), this,
+            SLOT(OnSwapScreens()));
+#endif
+}
+
+void RoomViewWindow::SetDefaultUIGeometry() {
+#if 0
+    // geometry: 55% of the window contents are in the upper screen half, 45% in the lower half
+    const QRect screenRect = QApplication::desktop()->screenGeometry(this);
+
+    const int w = screenRect.width() * 2 / 3;
+    const int h = screenRect.height() / 2;
+    const int x = (screenRect.x() + screenRect.width()) / 2 - w / 2;
+    const int y = (screenRect.y() + screenRect.height()) / 2 - h * 55 / 100;
+
+    setGeometry(x, y, w, h);
+#endif
+}
+
+void RoomViewWindow::RestoreUIState() {
+#if 0
+    restoreGeometry(UISettings::values.geometry);
+    restoreState(UISettings::values.state);
+    render_window->restoreGeometry(UISettings::values.renderwindow_geometry);
+#if MICROPROFILE_ENABLED
+    microProfileDialog->restoreGeometry(UISettings::values.microprofile_geometry);
+    microProfileDialog->setVisible(UISettings::values.microprofile_visible);
+#endif
+
+    game_list->LoadInterfaceLayout();
+
+    ui.action_Single_Window_Mode->setChecked(UISettings::values.single_window_mode);
+    ToggleWindowMode();
+
+    ui.action_Display_Dock_Widget_Headers->setChecked(UISettings::values.display_titlebar);
+    OnDisplayTitleBars(ui.action_Display_Dock_Widget_Headers->isChecked());
+
+    ui.action_Show_Status_Bar->setChecked(UISettings::values.show_status_bar);
+    statusBar()->setVisible(ui.action_Show_Status_Bar->isChecked());
+#endif
+}
+
+void RoomViewWindow::ConnectWidgetEvents() {
+#if 0
+    connect(game_list, SIGNAL(GameChosen(QString)), this, SLOT(OnGameListLoadFile(QString)));
+    connect(game_list, SIGNAL(OpenSaveFolderRequested(u64)), this,
+            SLOT(OnGameListOpenSaveFolder(u64)));
+
+    connect(this, SIGNAL(EmulationStarting(EmuThread*)), render_window,
+            SLOT(OnEmulationStarting(EmuThread*)));
+    connect(this, SIGNAL(EmulationStopping()), render_window, SLOT(OnEmulationStopping()));
+
+    connect(&status_bar_update_timer, &QTimer::timeout, this, &RoomViewWindow::UpdateStatusBar);
+#endif
+}
+
+void RoomViewWindow::ConnectMenuEvents() {
+#if 0
+    // File
+    connect(ui.action_Load_File, &QAction::triggered, this, &RoomViewWindow::OnMenuLoadFile);
+    connect(ui.action_Load_Symbol_Map, &QAction::triggered, this,
+            &RoomViewWindow::OnMenuLoadSymbolMap);
+    connect(ui.action_Select_Game_List_Root, &QAction::triggered, this,
+            &RoomViewWindow::OnMenuSelectGameListRoot);
+    connect(ui.action_Exit, &QAction::triggered, this, &QMainWindow::close);
+
+    // Emulation
+    connect(ui.action_Start, &QAction::triggered, this, &RoomViewWindow::OnStartGame);
+    connect(ui.action_Pause, &QAction::triggered, this, &RoomViewWindow::OnPauseGame);
+    connect(ui.action_Stop, &QAction::triggered, this, &RoomViewWindow::OnStopGame);
+    connect(ui.action_Configure, &QAction::triggered, this, &RoomViewWindow::OnConfigure);
+
+    // View
+    connect(ui.action_Single_Window_Mode, &QAction::triggered, this,
+            &RoomViewWindow::ToggleWindowMode);
+    connect(ui.action_Display_Dock_Widget_Headers, &QAction::triggered, this,
+            &RoomViewWindow::OnDisplayTitleBars);
+    connect(ui.action_Show_Status_Bar, &QAction::triggered, statusBar(), &QStatusBar::setVisible);
+#endif
+}
+
+#endif
+
+void RoomViewWindow::OnDisplayTitleBars(bool show) {
+#if 0
+    QList<QDockWidget*> widgets = findChildren<QDockWidget*>();
+
+    if (show) {
+        for (QDockWidget* widget : widgets) {
+            QWidget* old = widget->titleBarWidget();
+            widget->setTitleBarWidget(nullptr);
+            if (old != nullptr)
+                delete old;
+        }
+    } else {
+        for (QDockWidget* widget : widgets) {
+            QWidget* old = widget->titleBarWidget();
+            widget->setTitleBarWidget(new QWidget());
+            if (old != nullptr)
+                delete old;
+        }
+    }
+#endif
+}
+
+void RoomViewWindow::OnGameListOpenSaveFolder(u64 program_id) {
+#if 0
+    std::string sdmc_dir = FileUtil::GetUserPath(D_SDMC_IDX);
+    std::string path = FileSys::ArchiveSource_SDSaveData::GetSaveDataPathFor(sdmc_dir, program_id);
+    QString qpath = QString::fromStdString(path);
+
+    QDir dir(qpath);
+    if (!dir.exists()) {
+        QMessageBox::critical(this, tr("Error Opening Save Folder"), tr("Folder does not exist!"));
+        return;
+    }
+
+    LOG_INFO(Frontend, "Opening save data path for program_id=%" PRIu64, program_id);
+    QDesktopServices::openUrl(QUrl::fromLocalFile(qpath));
+#endif
+}
+
+void RoomViewWindow::OnMenuLoadFile() {
+#if 0
+    QString extensions;
+    for (const auto& piece : game_list->supported_file_extensions)
+        extensions += "*." + piece + " ";
+
+    QString file_filter = tr("3DS Executable") + " (" + extensions + ")";
+    file_filter += ";;" + tr("All Files (*.*)");
+
+    QString filename = QFileDialog::getOpenFileName(this, tr("Load File"),
+                                                    UISettings::values.roms_path, file_filter);
+    if (!filename.isEmpty()) {
+        UISettings::values.roms_path = QFileInfo(filename).path();
+
+        BootGame(filename);
+    }
+#endif
+}
+
+void RoomViewWindow::OnMenuLoadSymbolMap() {
+#if 0
+    QString filename = QFileDialog::getOpenFileName(
+        this, tr("Load Symbol Map"), UISettings::values.symbols_path, tr("Symbol Map (*.*)"));
+    if (!filename.isEmpty()) {
+        UISettings::values.symbols_path = QFileInfo(filename).path();
+
+        LoadSymbolMap(filename.toStdString());
+    }
+#endif
+}
+
+void RoomViewWindow::OnMenuSelectGameListRoot() {
+#if 0
+    QString dir_path = QFileDialog::getExistingDirectory(this, tr("Select Directory"));
+    if (!dir_path.isEmpty()) {
+        UISettings::values.gamedir = dir_path;
+        game_list->PopulateAsync(dir_path, UISettings::values.gamedir_deepscan);
+    }
+#endif
+}
+
+void RoomViewWindow::OnMenuRecentFile() {
+#if 0
+    QAction* action = qobject_cast<QAction*>(sender());
+    assert(action);
+
+    QString filename = action->data().toString();
+    QFileInfo file_info(filename);
+    if (file_info.exists()) {
+        BootGame(filename);
+    } else {
+        // Display an error message and remove the file from the list.
+        QMessageBox::information(this, tr("File not found"),
+                                 tr("File \"%1\" not found").arg(filename));
+
+        UISettings::values.recent_files.removeOne(filename);
+        UpdateRecentFiles();
+    }
+#endif
+}
+
+void RoomViewWindow::OnStartGame() {
+#if 0
+    emu_thread->SetRunning(true);
+
+    ui.action_Start->setEnabled(false);
+    ui.action_Start->setText(tr("Continue"));
+
+    ui.action_Pause->setEnabled(true);
+    ui.action_Stop->setEnabled(true);
+#endif
+}
+
+void RoomViewWindow::OnPauseGame() {
+#if 0
+    emu_thread->SetRunning(false);
+
+    ui.action_Start->setEnabled(true);
+    ui.action_Pause->setEnabled(false);
+    ui.action_Stop->setEnabled(true);
+#endif
+}
+
+void RoomViewWindow::OnStopGame() {
+#if 0
+    ShutdownGame();
+#endif
+}
+
+void RoomViewWindow::ToggleWindowMode() {
+#if 0
+    if (ui.action_Single_Window_Mode->isChecked()) {
+        // Render in the main window...
+        render_window->BackupGeometry();
+        ui.horizontalLayout->addWidget(render_window);
+        render_window->setFocusPolicy(Qt::ClickFocus);
+        if (emulation_running) {
+            render_window->setVisible(true);
+            render_window->setFocus();
+            game_list->hide();
+        }
+
+    } else {
+        // Render in a separate window...
+        ui.horizontalLayout->removeWidget(render_window);
+        render_window->setParent(nullptr);
+        render_window->setFocusPolicy(Qt::NoFocus);
+        if (emulation_running) {
+            render_window->setVisible(true);
+            render_window->RestoreGeometry();
+            game_list->show();
+        }
+    }
+#endif
+}
+
+void RoomViewWindow::OnConfigure() {
+#if 0
+    ConfigureDialog configureDialog(this);
+    auto result = configureDialog.exec();
+    if (result == QDialog::Accepted) {
+        configureDialog.applyConfiguration();
+        render_window->ReloadSetKeymaps();
+        config->Save();
+    }
+#endif
+}
+
+void RoomViewWindow::OnSwapScreens() {
+#if 0
+    Settings::values.swap_screen = !Settings::values.swap_screen;
+    Settings::Apply();
+#endif
+}
+
+void RoomViewWindow::OnCreateGraphicsSurfaceViewer() {
+#if 0
+    auto graphicsSurfaceViewerWidget = new GraphicsSurfaceWidget(Pica::g_debug_context, this);
+    addDockWidget(Qt::RightDockWidgetArea, graphicsSurfaceViewerWidget);
+    // TODO: Maybe graphicsSurfaceViewerWidget->setFloating(true);
+    graphicsSurfaceViewerWidget->show();
+#endif
+}
+
+void RoomViewWindow::UpdateStatusBar() {
+#if 0
+    if (emu_thread == nullptr) {
+        status_bar_update_timer.stop();
+        return;
+    }
+
+    auto results = Core::System::GetInstance().GetAndResetPerfStats();
+
+    emu_speed_label->setText(tr("Speed: %1%").arg(results.emulation_speed * 100.0, 0, 'f', 0));
+    game_fps_label->setText(tr("Game: %1 FPS").arg(results.game_fps, 0, 'f', 0));
+    emu_frametime_label->setText(tr("Frame: %1 ms").arg(results.frametime * 1000.0, 0, 'f', 2));
+
+    emu_speed_label->setVisible(true);
+    game_fps_label->setVisible(true);
+    emu_frametime_label->setVisible(true);
+#endif
+}
+
+bool RoomViewWindow::ConfirmClose() {
+    auto answer = QMessageBox::question(
+        this, tr("Citra"),
+        tr("Are you sure you want to leave this room? All other members will loose connection to you."),
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+    return answer != QMessageBox::No;
+}
+
+void RoomViewWindow::closeEvent(QCloseEvent* event) {
+#if 0
+    if (!ConfirmClose()) {
+        event->ignore();
+        return;
+    }
+
+    UISettings::values.geometry = saveGeometry();
+    UISettings::values.state = saveState();
+    UISettings::values.renderwindow_geometry = render_window->saveGeometry();
+#if MICROPROFILE_ENABLED
+    UISettings::values.microprofile_geometry = microProfileDialog->saveGeometry();
+    UISettings::values.microprofile_visible = microProfileDialog->isVisible();
+#endif
+    UISettings::values.single_window_mode = ui.action_Single_Window_Mode->isChecked();
+    UISettings::values.display_titlebar = ui.action_Display_Dock_Widget_Headers->isChecked();
+    UISettings::values.show_status_bar = ui.action_Show_Status_Bar->isChecked();
+    UISettings::values.first_start = false;
+
+    game_list->SaveInterfaceLayout();
+    SaveHotkeys();
+
+    // Shutdown session if the emu thread is active...
+    if (emu_thread != nullptr)
+        ShutdownGame();
+
+    render_window->close();
+
+    QWidget::closeEvent(event);
+#endif
+}

--- a/src/frontend/room_view_window.h
+++ b/src/frontend/room_view_window.h
@@ -7,6 +7,8 @@
 #ifndef _CITRA_QT_ROOM_VIEW_WINDOW_HXX_
 #define _CITRA_QT_ROOM_VIEW_WINDOW_HXX_
 
+#include "tunnler/room_member.h"
+
 #include <memory>
 #include <QMainWindow>
 #include <QLabel>
@@ -70,6 +72,7 @@ private:
     void closeEvent(QCloseEvent* event) override;
 
 private slots:
+    void OnSay();
     void OnStartGame();
     void OnPauseGame();
     void OnStopGame();
@@ -89,6 +92,9 @@ private slots:
 
 private:
     void UpdateStatusBar();
+
+
+RoomMember room_member;
 
     //Ui::MainWindow ui;
 

--- a/src/frontend/room_view_window.h
+++ b/src/frontend/room_view_window.h
@@ -77,6 +77,8 @@ private:
     void AddChatMessage(QString nickname, QString message, bool outbound);
     void SetUiState(bool connected);
 
+    void UpdateMemberList();
+
 private slots: //FIXME: Use QString instead of std::string?
     void OnSay();
     void OnStateChange();
@@ -113,6 +115,8 @@ QPushButton* sayButton = nullptr; // <item row="1" column="2" >
     QLabel* game_fps_label = nullptr;
     QLabel* emu_frametime_label = nullptr;
     QTimer status_bar_update_timer;
+
+    QStandardItemModel* item_model = nullptr;
 
 #if 0
     std::unique_ptr<Config> config;

--- a/src/frontend/room_view_window.h
+++ b/src/frontend/room_view_window.h
@@ -71,24 +71,20 @@ private:
     bool ConfirmClose();
     void closeEvent(QCloseEvent* event) override;
 
-private slots:
+
+    void AddRoomMessage(QString message);
+    void AddConnectionMessage(QString message);
+    void AddChatMessage(QString nickname, QString message, bool outbound);
+    void SetUiState(bool connected);
+
+private slots: //FIXME: Use QString instead of std::string?
     void OnSay();
-    void OnStartGame();
-    void OnPauseGame();
-    void OnStopGame();
-    /// Called whenever a user selects a game in the game list widget.
-//    void OnGameListLoadFile(QString game_path);
-    void OnGameListOpenSaveFolder(u64 program_id);
-    void OnMenuLoadFile();
-    void OnMenuLoadSymbolMap();
-    /// Called whenever a user selects the "File->Select Game List Root" menu item
-    void OnMenuSelectGameListRoot();
-    void OnMenuRecentFile();
-    void OnSwapScreens();
-    void OnConfigure();
-    void OnDisplayTitleBars(bool);
-    void ToggleWindowMode();
-    void OnCreateGraphicsSurfaceViewer();
+    void OnStateChange();
+    void OnRoomGameChange(std::string game_name);
+    void OnMemberGameChange(std::string nickname, std::string game_name);
+    void OnDisconnected();
+    void OnMemberLeft(std::string nickname);
+    void OnMemberJoined(std::string nickname);
 
 private:
     void UpdateStatusBar();

--- a/src/frontend/room_view_window.h
+++ b/src/frontend/room_view_window.h
@@ -1,0 +1,139 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#define u64 uint64_t
+
+#ifndef _CITRA_QT_ROOM_VIEW_WINDOW_HXX_
+#define _CITRA_QT_ROOM_VIEW_WINDOW_HXX_
+
+#include <memory>
+#include <QMainWindow>
+#include <QLabel>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <QGridLayout>
+#include <QLineEdit>
+#include <QTreeView>
+#include <QPushButton>
+#include <QTextEdit>
+#if 0
+#include "ui_main.h"
+
+class CallstackWidget;
+class Config;
+class DisassemblerWidget;
+class EmuThread;
+#endif
+class RoomMemberList;
+#if 0
+class GImageInfo;
+class GPUCommandStreamWidget;
+class GPUCommandListWidget;
+class GraphicsBreakPointsWidget;
+class GraphicsTracingWidget;
+class GraphicsVertexShaderWidget;
+class GRenderWindow;
+class MicroProfileDialog;
+class ProfilerWidget;
+class RegistersWidget;
+class WaitTreeWidget;
+
+#endif
+
+class RoomViewWindow : public QMainWindow {
+    Q_OBJECT
+
+    typedef uint8_t EmuThread;
+
+    /// Max number of recently loaded items to keep track of
+    static const int max_recent_files_item = 10;
+
+public:
+    RoomViewWindow();
+    ~RoomViewWindow();
+
+private:
+    void InitializeWidgets();
+
+    void SetDefaultUIGeometry();
+    void RestoreUIState();
+
+    void ConnectWidgetEvents();
+
+    /**
+     * Ask the user if they really want to leave a room / close the window.
+     *
+     * @return true if the user confirmed
+     */
+    bool ConfirmClose();
+    void closeEvent(QCloseEvent* event) override;
+
+private slots:
+    void OnStartGame();
+    void OnPauseGame();
+    void OnStopGame();
+    /// Called whenever a user selects a game in the game list widget.
+//    void OnGameListLoadFile(QString game_path);
+    void OnGameListOpenSaveFolder(u64 program_id);
+    void OnMenuLoadFile();
+    void OnMenuLoadSymbolMap();
+    /// Called whenever a user selects the "File->Select Game List Root" menu item
+    void OnMenuSelectGameListRoot();
+    void OnMenuRecentFile();
+    void OnSwapScreens();
+    void OnConfigure();
+    void OnDisplayTitleBars(bool);
+    void ToggleWindowMode();
+    void OnCreateGraphicsSurfaceViewer();
+
+private:
+    void UpdateStatusBar();
+
+    //Ui::MainWindow ui;
+
+/*
+    GRenderWindow* render_window;
+*/
+
+QWidget* centralwidget = nullptr;
+QVBoxLayout* verticalLayout = nullptr;
+
+QWidget* chatWidget = nullptr;
+QGridLayout* gridLayout = nullptr;
+QTextEdit* chatLog = nullptr;
+QTreeView* memberList = nullptr; // <item row="0" column="1" colspan="2" >
+QLineEdit* sayLineEdit = nullptr; // <item row="1" column="0" colspan="2" >           
+QPushButton* sayButton = nullptr; // <item row="1" column="2" >
+
+    // Status bar elements
+    QLabel* emu_speed_label = nullptr;
+    QLabel* game_fps_label = nullptr;
+    QLabel* emu_frametime_label = nullptr;
+    QTimer status_bar_update_timer;
+
+#if 0
+    std::unique_ptr<Config> config;
+
+    // Whether emulation is currently running in Citra.
+    bool emulation_running = false;
+    std::unique_ptr<EmuThread> emu_thread;
+
+    // Debugger panes
+    ProfilerWidget* profilerWidget;
+    MicroProfileDialog* microProfileDialog;
+    DisassemblerWidget* disasmWidget;
+    RegistersWidget* registersWidget;
+    CallstackWidget* callstackWidget;
+    GPUCommandStreamWidget* graphicsWidget;
+    GPUCommandListWidget* graphicsCommandsWidget;
+    GraphicsBreakPointsWidget* graphicsBreakpointsWidget;
+    GraphicsVertexShaderWidget* graphicsVertexShaderWidget;
+    GraphicsTracingWidget* graphicsTracingWidget;
+    WaitTreeWidget* waitTreeWidget;
+
+    QAction* actions_recent_files[max_recent_files_item];
+#endif
+};
+
+#endif // _CITRA_QT_ROOM_VIEW_WINDOW_HXX_

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -1,0 +1,122 @@
+#include "MessageIdentifiers.h"
+
+#include "RakPeerInterface.h"
+#include "RakPeerInterface.h"
+#include "RakNetTypes.h"
+#include "GetTime.h"
+#include "BitStream.h"
+
+#include <assert.h>
+#include <cstdio>
+#include <cstring>
+#include <stdlib.h>
+
+#include "RakSleep.h"
+#include "Gets.h"
+
+//FIXME: Maybe seperate this into an interface and have LocalNetworkLobby and MasterServerLobby ?
+class Lobby {
+
+// Pointers to the interfaces of our server and client.
+// Note we can easily have both in the same program
+RakNet::RakPeerInterface *client = RakNet::RakPeerInterface::GetInstance();
+bool b;
+char str[256];
+RakNet::TimeMS quitTime;
+// Holds packets
+RakNet::Packet* p;  
+
+public:
+
+struct RoomInformation {
+  std::string name;
+  //FIXME: Can we somehow extract a game title id from UDS or something?
+  //FIXME: Can we somehow check the NWM cryptokey for validity?
+  unsigned int users;
+  unsigned int maxUsers;
+};
+
+struct FoundRoom {
+  bool local; // Wether this was retrieved from a master list or LAN scan
+  std::string server;
+  unsigned int serverPort;
+    //FIXME: Store some timestamp when this was last alive, if it's too old it should probably be removed
+  RoomInformation information;
+  unsigned int ping;
+};
+
+private:
+
+std::vector<FoundRoom> foundRooms;
+
+public:
+
+~Lobby() {
+    // We're done with the network
+  if (client) {
+    RakNet::RakPeerInterface::DestroyInstance(client);
+  }
+}
+
+static void processLocalNetworkData() {
+  // Loop for input
+//  while (RakNet::GetTimeMS() < quitTime) {
+  p = client->Receive();
+
+  if (p == nullptr) {
+    return;
+  }
+
+  switch(p->data[0]) {
+  case ID_UNCONNECTED_PONG:
+    RakNet::TimeMS time;
+    RakNet::BitStream bsIn(p->data,p->length,false);
+    bsIn.IgnoreBytes(1);
+    bsIn.Read(time);
+    printf("Got pong from %s with time %i\n", p->systemAddress.ToString(), RakNet::GetTimeMS() - time);
+    break;
+  case ID_UNCONNECTED_PING:
+    printf("ID_UNCONNECTED_PING from %s\n",p->guid.ToString());
+    break;
+  case ID_UNCONNECTED_PING_OPEN_CONNECTIONS) {
+    printf("ID_UNCONNECTED_PING_OPEN_CONNECTIONS from %s\n",p->guid.ToString());
+    break;
+  default:
+    printf("Oops!\n");
+    break;
+  }
+  client->DeallocatePacket(p);
+}
+
+// This might take some time to process
+void sendPing() {
+  //FIXME: Send a ping to all rooms
+}
+
+void updateFoundRooms(unsigned int expirationTime = 5000) {
+  processLocalNetworkData();
+  //FIXME: Remove dead servers = those who did not respond to ping in the last X milliseconds
+
+  
+
+}
+
+//FIXME: Make the parameter some chrono:: crap
+std::vector<FoundRoom> retrieveFoundRooms() {
+  return foundRooms;
+}
+
+void scan(unsigned int serverPort = 1234, unsigned int clientPort = 0) {
+
+  RakNet::SocketDescriptor socketDescriptor(clientPort, 0);
+  socketDescriptor.socketFamily = AF_INET; // Only IPV4 supports broadcast on 255.255.255.255
+  client->Startup(1, &socketDescriptor, 1);
+
+  // Connecting the client is very simple.  0 means we don't care about
+  // a connectionValidationInteger, and false for low priority threads
+  // All 255's mean broadcast
+  client->Ping("255.255.255.255", serverPort, false);
+  printf("Ping-ed\n");
+}
+
+};

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -1,3 +1,5 @@
+#include "tunnler/lobby.h"
+
 #include "MessageIdentifiers.h"
 
 #include "RakPeerInterface.h"
@@ -14,56 +16,37 @@
 #include "RakSleep.h"
 #include "Gets.h"
 
-#include "restclient-cpp/connection.h"
-#include "restclient-cpp/restclient.h"
+#include <cpr/cpr.h>
 
-//FIXME: Maybe seperate this into an interface and have LocalNetworkLobby and MasterServerLobby ?
-class Lobby {
+#if 0
+#include <cpprest/http_client.h>
+#include <cpprest/filestream.h>
 
-// Pointers to the interfaces of our server and client.
-// Note we can easily have both in the same program
-RakNet::RakPeerInterface *client = RakNet::RakPeerInterface::GetInstance();
-bool b;
-char str[256];
-RakNet::TimeMS quitTime;
-// Holds packets
-RakNet::Packet* p;  
+using namespace utility;                    // Common utilities like string conversions
+//using namespace web;                        // Common features like URIs.
+using namespace web::http;                  // Common HTTP functionality
+using namespace web::http::client;          // HTTP client features
+using namespace concurrency::streams;       // As
 
-public:
+//#include "restclient-cpp/connection.h"
+//#include "restclient-cpp/restclient.h"
 
-struct RoomInformation {
-  std::string name;
-  //FIXME: Can we somehow extract a game title id from UDS or something?
-  //FIXME: Can we somehow check the NWM cryptokey for validity?
-  unsigned int users;
-  unsigned int maxUsers;
-};
+#endif
 
-struct FoundRoom {
-  bool local; // Wether this was retrieved from a master list or LAN scan
-  std::string server;
-  unsigned int serverPort;
-    //FIXME: Store some timestamp when this was last alive, if it's too old it should probably be removed
-  RoomInformation information;
-  unsigned int ping;
-};
+#include "json.hpp"
 
-private:
+using json = nlohmann::json;
 
-std::vector<FoundRoom> foundRooms;
-
-public:
-
-~Lobby() {
+Lobby::~Lobby() {
     // We're done with the network
-  if (client) {
-    RakNet::RakPeerInterface::DestroyInstance(client);
-  }
+    if (client) {
+        RakNet::RakPeerInterface::DestroyInstance(client);
+    }
 }
 
 static void processInternetData(std::string masterServer) {
   //FIXME: do some rest requests
-
+#if 0
   // initialize RestClient
   RestClient::init();
 
@@ -93,6 +76,9 @@ static void processInternetData(std::string masterServer) {
 
   // if using a non-standard Certificate Authority (CA) trust file
 //  conn->SetCAInfoFilePath("/etc/custom-ca.crt")
+#endif
+
+}
 
 /*
 
@@ -105,64 +91,80 @@ PUT - A keep alive packet that keeps the room from automatically being destroyed
 
 */
 
-const std::string Path = "/room";
+std::vector<Lobby::FoundRoom> Lobby::GetRooms() {
+    auto url = cpr::Url{MasterServer + Path};
+    auto response = cpr::Get(url);
+#if 0
+    std::cout << "Trying to parse results from request with status " << response.status_code << std::endl;
+#endif
 
-struct RoomAddress {
-  std::string server;
-  uint16_t serverPort;
-};
+    if (response.status_code != 200) {
+        return {};
+    }
 
-std::vector<RoomAddress> getRooms() {
-  RestClient::Response r = conn->get(Path);
-  //FIXME: Json foo to split a "rooms" object into the vector
-  return r->body;
+    std::vector<Lobby::FoundRoom> found_rooms;
+
+    auto room_addresses_json = json::parse(response.text);
+    for(auto room_address_json : room_addresses_json) {
+
+        auto GetMandatoryKey = [&](const std::string& key, auto& value, json::value_t type) -> bool {
+            auto element = room_address_json.find(key);
+            if (element == room_address_json.end()) {
+                return false;
+            }
+            if (element->type() != type) {
+                return false;
+            }
+            value = room_address_json[key];
+            return true;
+        };
+
+        Lobby::FoundRoom found_room;
+
+        if (!GetMandatoryKey("server", found_room.server, json::value_t::string)) {
+            continue;
+        }
+        if (!GetMandatoryKey("serverPort", found_room.server_port, json::value_t::number_unsigned)) {
+            continue;
+        }
+
+        found_rooms.push_back(found_room);
+    }
+    return found_rooms;
 }
 
 // Returns a token
-std::string createRoom(std::string server, uint16_t serverPort) {
-  RestClient::Response r = conn->post(Path, "{\"server\": \"" + server + "\"; \"serverPort\": " + std::to_string(serverPort) + "}");
-  if (r->status != 200) {
-    return "";
-  }
-  return r->body;
+std::string Lobby::CreateRoom(std::string server, uint16_t server_port) {
+    auto url = cpr::Url{MasterServer + Path};
+    json body;
+    body["server"] = server;
+    body["serverPort"] = server_port;
+    auto response = cpr::Post(url, cpr::Body(body.dump(4)));
+    return response.text;
 }
 
-bool updateRoom(std::string token) {
-  RestClient::Response r = conn->put(Path, "{\"token\": \"" + token + "\"}"); // FIXME: Escape token!
-  return r->status == 200;
+bool Lobby::UpdateRoom(std::string token) {
+    auto url = cpr::Url{MasterServer + Path};
+    json body;
+    body["token"] = token;
+    auto response = cpr::Put(url, cpr::Body(body.dump(4)));
+    return response.status_code == 200;
 }
 
-bool destroyRoom(std::string token) {
-  RestClient::Response r = conn->del(Path, "{\"token\": \"" + token + "\"}"); // FIXME: Escape token!
-  return r->status == 200;
+bool Lobby::DestroyRoom(std::string token) {
+    auto url = cpr::Url{MasterServer + Path};
+    json body;
+    body["token"] = token;
+    auto response = cpr::Delete(url, cpr::Body(body.dump(4)));
+    return response.status_code == 200;
 }
 
-//RestClient::Response r = conn->post("/room", "{\"foo\": \"bla\"}")
-
-#if 0
-{
-  RestClient::Response r = conn->get("/get")
-}
-  RestClient::Response r = conn->head("/get")
-{
-  RestClient::Response r = conn->del("/delete")
-}
-#endif
-
-  // set different content header for POST and PUT
-  conn->AppendHeader("Content-Type", "text/json");
-//  RestClient::Response r = conn->post("/post", "{\"foo\": \"bla\"}")
-//  RestClient::Response r = conn->put("/put", "text/json", "{\"foo\": \"bla\"}")
-
-  // deinit RestClient. After calling this you have to call RestClient::init()
-  // again before you can use it
-  RestClient::disable();
-
-}
-
-static void processLocalNetworkData() {
+void Lobby::processLocalNetworkData() {
   // Loop for input
-//  while (RakNet::GetTimeMS() < quitTime) {
+//  while (RakNet::GetTimeMS() < quit_time) {
+
+#if 1
+
   p = client->Receive();
 
   if (p == nullptr) {
@@ -170,17 +172,18 @@ static void processLocalNetworkData() {
   }
 
   switch(p->data[0]) {
-  case ID_UNCONNECTED_PONG:
+  case ID_UNCONNECTED_PONG: {
     RakNet::TimeMS time;
     RakNet::BitStream bsIn(p->data,p->length,false);
     bsIn.IgnoreBytes(1);
     bsIn.Read(time);
     printf("Got pong from %s with time %i\n", p->systemAddress.ToString(), RakNet::GetTimeMS() - time);
     break;
+  }
   case ID_UNCONNECTED_PING:
     printf("ID_UNCONNECTED_PING from %s\n",p->guid.ToString());
     break;
-  case ID_UNCONNECTED_PING_OPEN_CONNECTIONS) {
+  case ID_UNCONNECTED_PING_OPEN_CONNECTIONS:
     printf("ID_UNCONNECTED_PING_OPEN_CONNECTIONS from %s\n",p->guid.ToString());
     break;
   default:
@@ -188,14 +191,31 @@ static void processLocalNetworkData() {
     break;
   }
   client->DeallocatePacket(p);
+
+#endif
 }
 
 // This might take some time to process
-void sendPing() {
-  //FIXME: Send a ping to all rooms
+Lobby::RoomInformation Lobby::GetRoomInformation(std::string server, uint16_t server_port, uint16_t client_port) {
+    RakNet::SocketDescriptor socketDescriptor(client_port, 0);
+    socketDescriptor.socketFamily = AF_INET; // Only IPV4 supports broadcast on 255.255.255.255
+
+    //FIXME:Create a temporary socket or grab one from a pool?!
+
+    client->Startup(1, &socketDescriptor, 1);
+    //FIXME: Send a ping to room
+    client->Ping(server.c_str(), server_port, false);
+
+    // Wait for a response
+    while(true) {
+      //FIXME!!!!
+      break;
+    }
+
+    return {};
 }
 
-void updateFoundRooms(unsigned int expirationTime = 5000) {
+void Lobby::updateFoundRooms(unsigned int expiration_time) {
   processLocalNetworkData();
   //FIXME: Remove dead servers = those who did not respond to ping in the last X milliseconds
 
@@ -204,21 +224,22 @@ void updateFoundRooms(unsigned int expirationTime = 5000) {
 }
 
 //FIXME: Make the parameter some chrono:: crap
-std::vector<FoundRoom> retrieveFoundRooms() {
+std::vector<Lobby::FoundRoom> Lobby::retrieveFoundRooms() {
   return foundRooms;
 }
 
-void scan(unsigned int serverPort = 1234, unsigned int clientPort = 0) {
-
-  RakNet::SocketDescriptor socketDescriptor(clientPort, 0);
+void Lobby::StartScan(unsigned int server_port, unsigned int client_port) {
+  RakNet::SocketDescriptor socketDescriptor(client_port, 0);
   socketDescriptor.socketFamily = AF_INET; // Only IPV4 supports broadcast on 255.255.255.255
   client->Startup(1, &socketDescriptor, 1);
 
   // Connecting the client is very simple.  0 means we don't care about
   // a connectionValidationInteger, and false for low priority threads
   // All 255's mean broadcast
-  client->Ping("255.255.255.255", serverPort, false);
+  client->Ping("255.255.255.255", server_port, false);
   printf("Ping-ed\n");
 }
 
-};
+void Lobby::StopScan() {
+  printf("FIXME! Kill socket!\n");
+}

--- a/src/masterserver/rooms.php
+++ b/src/masterserver/rooms.php
@@ -1,0 +1,185 @@
+<?php
+/*
+
+(c) Tunnler Project 2017
+
+Going full yolo on this one.
+
+Run using: `php -S localhost:8000 -t .`
+
+*/
+
+const rooms_file = "/tmp/rooms.json";
+const timeout = 1 * 60; // seconds
+
+// from https://gist.github.com/umidjons/42d378dc7d649c659a07
+function randHash($len = 32) {
+	return substr(md5(openssl_random_pseudo_bytes(20)), -$len);
+}
+
+function timestamp() {
+  return time();
+}
+
+function filterRooms($rooms) {
+  $deadline = timestamp() - timeout;
+  foreach ($rooms as $token => $room) {
+    if ($room['lastSeen'] <= $deadline) {  
+      unset($rooms[$token]);
+    }
+  }
+
+  return $rooms;
+}
+
+function loadRoomsFromDB() {
+  if (!file_exists(rooms_file)) {
+    return array();
+  }
+  $roomsJson = file_get_contents(rooms_file);
+  $rooms = json_decode($roomsJson, TRUE);
+  return filterRooms($rooms);
+}
+
+function saveRoomsToDB($rooms) {
+  $roomsJson = json_encode($rooms, JSON_PRETTY_PRINT);
+  file_put_contents(rooms_file, $roomsJson);
+}
+
+function getRooms() {
+  $rooms = loadRoomsFromDB();
+  saveRoomsToDB($rooms);
+
+  // Create a new list which only exists data which the user is allowed to see
+  $publicRoomsData = array();
+  foreach ($rooms as $token => $room) {
+    $publicRoomData = array(
+      'server' => $room['server'],
+      'serverPort' => $room['serverPort']
+    );
+    array_push($publicRoomsData, $publicRoomData);
+  }
+
+  return json_encode($publicRoomsData, JSON_PRETTY_PRINT);
+}
+
+function createRoom($server, $serverPort) {
+  
+  //FIXME: Do sanity checking on all arguments
+  //FIXME: AT THE VERY LEAST CHECK FOR LARGE DATA HERE!
+
+  $rooms = loadRoomsFromDB();
+  
+  // FIXME: Check if this server is already in the list / we don't want duplicates..
+  if (false) {
+    return '';
+  }
+
+  // Generate a valid token
+  do {
+    $token = randHash();
+  } while(in_array($token, $rooms));
+
+  // Add the room
+  $room = array(
+    'server' => $server,
+    'serverPort' => $serverPort,
+    'lastSeen' => timestamp()
+  );
+  $rooms = array_merge($rooms, array($token => $room));
+
+  saveRoomsToDB($rooms);
+
+  // Return the rooms token
+  return $token;
+}
+
+function destroyRoom($token) {
+  $rooms = loadRoomsFromDB();
+
+  // Make sure the room even exists
+  if (!in_array($token, $rooms)) {
+    return 'not_found';
+  }
+
+  unset($rooms[$token]);
+
+  saveRoomsToDB($rooms);
+  return 'ok';
+}
+
+function updateRoom($token) {
+  $rooms = loadRoomsFromDB();
+
+  var_dump($rooms);
+
+  // Make sure the room even exists
+  if (!in_array($token, $rooms)) { //FIXME: Gets stuck in this
+    return 'not_found';
+  }
+
+  $rooms[$token]['lastSeen'] = timestamp();
+
+  saveRoomsToDB($rooms);
+  return 'ok';
+}
+ 
+// get the HTTP method, path and body of the request
+$method = $_SERVER['REQUEST_METHOD'];
+//$request = explode('/', trim($_SERVER['PATH_INFO'], '/'));
+$input = json_decode(file_get_contents('php://input'), true);
+ 
+/*
+// connect to the mysql database
+$link = mysqli_connect('localhost', 'user', 'pass', 'dbname');
+mysqli_set_charset($link,'utf8');
+ 
+// retrieve the table and key from the path
+$table = preg_replace('/[^a-z0-9_]+/i','',array_shift($request));
+$key = array_shift($request)+0;
+ 
+// escape the columns and values from the input object
+$columns = preg_replace('/[^a-z0-9_]+/i','',array_keys($input));
+$values = array_map(function ($value) use ($link) {
+  if ($value===null) return null;
+  return mysqli_real_escape_string($link,(string)$value);
+},array_values($input));
+ 
+// build the SET part of the SQL command
+$set = '';
+for ($i=0;$i<count($columns);$i++) {
+  $set.=($i>0?',':'').'`'.$columns[$i].'`=';
+  $set.=($values[$i]===null?'NULL':'"'.$values[$i].'"');
+}
+*/
+ 
+// Do action based on HTTP method
+$response = 'unknown';
+switch ($method) {
+  case 'GET':
+    $response = getRooms();
+    break;
+  case 'PUT':
+    //FIXME: Get 'server', 'serverPort'
+    $response = createRoom($input['server'], $input['serverPort']);
+    break;
+  case 'POST':
+    //FIXME: Get token
+    $response = updateRoom($input['token']);
+    break;
+  case 'DELETE':
+    //FIXME: Get token
+    $response = destroyRoom($input['token']);
+    break;
+}
+
+echo $response;
+
+/* 
+if (!$result) {
+  http_response_code(404);
+  die(mysqli_error());
+}
+*/
+ 
+?>

--- a/src/masterserver/rooms.php
+++ b/src/masterserver/rooms.php
@@ -78,7 +78,7 @@ function createRoom($server, $serverPort) {
   // Generate a valid token
   do {
     $token = randHash();
-  } while(in_array($token, $rooms));
+  } while(array_key_exists($token, $rooms));
 
   // Add the room
   $room = array(
@@ -98,7 +98,8 @@ function destroyRoom($token) {
   $rooms = loadRoomsFromDB();
 
   // Make sure the room even exists
-  if (!in_array($token, $rooms)) {
+  if (!array_key_exists($token, $rooms)) {
+http_response_code(404); // FIXME:!
     return 'not_found';
   }
 
@@ -114,7 +115,7 @@ function updateRoom($token) {
   var_dump($rooms);
 
   // Make sure the room even exists
-  if (!in_array($token, $rooms)) { //FIXME: Gets stuck in this
+  if (!array_key_exists($token, $rooms)) { //FIXME: Gets stuck in this
     return 'not_found';
   }
 
@@ -159,16 +160,13 @@ switch ($method) {
   case 'GET':
     $response = getRooms();
     break;
-  case 'PUT':
-    //FIXME: Get 'server', 'serverPort'
+  case 'POST':
     $response = createRoom($input['server'], $input['serverPort']);
     break;
-  case 'POST':
-    //FIXME: Get token
+  case 'PUT':
     $response = updateRoom($input['token']);
     break;
   case 'DELETE':
-    //FIXME: Get token
     $response = destroyRoom($input['token']);
     break;
 }

--- a/src/room.cpp
+++ b/src/room.cpp
@@ -20,6 +20,9 @@ void Room::Create(const std::string& name, const std::string& server_address, ui
     server->Startup(MaxConcurrentConnections, &socket, 1);
     server->SetMaximumIncomingConnections(MaxConcurrentConnections);
 
+    std::vector<uint8_t> foo;
+    server->SetOfflinePingResponse((char*)foo.data(), foo.size());
+
     state = State::Open;
 
     // Start a network thread to Receive packets in a loop.

--- a/src/room_member.cpp
+++ b/src/room_member.cpp
@@ -160,7 +160,7 @@ std::deque<WifiPacket> RoomMember::PopWifiPackets(WifiPacket::PacketType type, c
 }
 
 void RoomMember::SendChatMessage(const std::string& message) {
-    std::cout << "Trying to send: " << message << std::endl;
+    std::cout << "Trying to send: '" << message << "'" << std::endl;
     RakNet::BitStream stream;
 
     stream.Write(static_cast<RakNet::MessageID>(ID_ROOM_CHAT));

--- a/src/samples/CMakeLists.txt
+++ b/src/samples/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/Modules/")
+
+add_executable(server server.cpp)
+#target_link_libraries(server ${PLATFORM_LIBRARIES} Threads::Threads)
+target_link_libraries(server tunnler)
+
+add_executable(lobby lobby.cpp)
+#target_link_libraries(lobby ${PLATFORM_LIBRARIES} Threads::Threads)
+target_link_libraries(lobby tunnler)

--- a/src/samples/lobby.cpp
+++ b/src/samples/lobby.cpp
@@ -1,0 +1,95 @@
+#include <iostream>
+#include <chrono>
+#include <thread>
+#include <memory>
+
+using namespace std::chrono_literals;
+
+#include "tunnler/lobby.h"
+
+const std::string MasterServer = "http://127.0.0.1:8000/"; //FIXME: Use
+
+int main(int argc, char* argv[]) {
+    std::cout << "Lobby example" << std::endl;
+
+    Lobby lobby;
+
+    auto ListRooms = [&]() {
+        std::cout << "Retrieving rooms" << std::endl;
+
+        std::vector<Lobby::FoundRoom> rooms = lobby.GetRooms();
+        for(auto& room : rooms) {
+            std::cout << "Found room: \"" << room.server << "\" (Port " << room.server_port << ")" << std::endl;
+            if (!room.information) {
+              room.information = std::make_shared<Lobby::RoomInformation>(lobby.GetRoomInformation(room.server, room.server_port));
+              std::cout << "Querying information.." << std::endl;
+            } else {
+              //FIXME: We already have the info!
+              std::cout << "Information:" << std::endl;
+            }
+        }
+    };
+
+#if 0
+
+    std::string token_a = lobby.CreateRoom("server-a", 1234);
+    std::cout << "Created room \"" << token_a << "\"" << std::endl;
+
+    std::string token_b = lobby.CreateRoom("server-b", 1234);
+    std::cout << "Created room \"" << token_b << "\"" << std::endl;
+
+    ListRooms();
+
+    std::cout << "Destroyed? " << lobby.DestroyRoom(token_a) << std::endl;
+
+    ListRooms();
+#endif
+
+    std::vector<std::string> args(argv, argv + argc);
+
+    if (args.size() >= 2) {
+
+        std::string command = args[1];
+        if (command == "list") {
+
+            // Do some LAN discovery
+            uint16_t server_port = 1234; //atoi(args[2].c_str());
+            std::cout << "Starting scan" << std::endl;
+            lobby.StartScan(server_port);
+            std::this_thread::sleep_for(1s);
+            std::cout << "Stopping scan" << std::endl;
+
+lobby.updateFoundRooms();
+
+            lobby.StopScan();
+/*
+            for(auto& room : rooms) {
+                if (!room.information) {
+                    room.information = std::make_shared(lobby.GetRoomInformation(room));
+                }
+            }
+*/
+            std::this_thread::sleep_for(1s);
+
+            ListRooms();
+        } else if (command == "create") {
+            std::string server = args[2];
+            uint16_t server_port = atoi(args[3].c_str());
+            std::string token = lobby.CreateRoom(server, server_port);
+            std::cout << "Token: \"" << token << "\"" << std::endl;
+        } else if (command == "destroy") {
+            std::string token = args[2];
+            bool status = lobby.DestroyRoom(token);
+            std::cout << "Status: " << (status ? "Success" : "Failure") << std::endl;
+        } else if (command == "update") {
+            std::string token = args[2];
+            bool status = lobby.UpdateRoom(token);
+            std::cout << "Status: " << (status ? "Success" : "Failure") << std::endl;
+        } else {
+            std::cerr << "Unknown command \"" << args[0] << "\"" << std::endl;
+        }
+
+    }
+
+    return 0;
+}

--- a/src/samples/main.cpp
+++ b/src/samples/main.cpp
@@ -1,0 +1,87 @@
+//
+//  main.cpp
+//  tunnler
+//
+//
+
+#include <deque>
+#include <memory>
+#include <cstdio>
+#include <iostream>
+
+#include "pcapHandle.hpp"
+#include "RakPeerInterface.h"
+#include "RakString.h"
+
+#include <stdio.h>
+#include <unistd.h>
+
+#include "room.h"
+
+const char* src_mac_address ="08:96:d7:e4:6a:9e";	//Fill in MAC of your device
+const bool isServer = true;
+
+int main(int argc, char* argv[]) {
+	std::deque<u_char*> data_buffer;
+
+  if (argc != 5) {
+    std::cerr << "Usage: " << argv[0] << " <device> <server> <server-port> <nickname>" << std::endl;
+    return 1;
+  }
+
+  std::string deviceName = std::string(argv[1]);
+  std::string server = std::string(argv[2]);
+  unsigned int serverPort = atoi(argv[3]);
+  std::string nickname = std::string(argv[4]);
+
+
+  std::shared_ptr<RoomMembership> room = std::make_shared<RoomMembership>();
+  room->join(nickname, server, serverPort);
+
+  while(true) {
+    // This sleep keeps RakNet responsive
+#ifdef _WIN32
+    Sleep(30);
+#else
+    usleep(30 * 1000);
+#endif
+
+    room->handleInput();
+    room->update();
+  }
+
+  //FIXME: Use wifi device name from devName
+
+	pcapHandle* pcap_handle = new pcapHandle(deviceName);
+	pcap_handle->activate();
+
+	char filter_arg[100];
+	sprintf(filter_arg, "ether src %s", src_mac_address );
+	pcap_handle->setFilter(filter_arg);
+	pcap_handle->setDumpFile("/tmp/capture.pcap");
+
+	std::cout << "start tunnel" << std::endl;
+	while(1) {
+
+    // Do connection management
+    room->update();
+
+    for(auto& p : room->getData()) {
+      std::cout << "Received data!" << std::endl;
+    }
+
+    for(auto& p : room->getChat()) {
+      std::cout << "Received chat!" << std::endl;
+    }
+
+		if(int length = pcap_handle->next()) {
+      std::vector<uint8> data_buffer(pcap_handle->data, pcap_handle->data + length);
+      std::cout << "Forwarding data!" << std::endl;
+      room->send(data_buffer);
+		}
+	}
+
+  room.reset();
+	delete pcap_handle;
+	std::cout << "done tunnel" << std::endl;
+}

--- a/src/samples/server.cpp
+++ b/src/samples/server.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+#include "tunnler/room.h"
+
+int main(int argc, char* argv[]) {
+    std::cout << "Server example" << std::endl;
+
+    std::vector<std::string> args(argv, argv + argc);
+
+    if (args.size() < 2) {
+        std::cerr << args[0] << " <name>" << std::endl;
+        return 1;
+    }
+
+    std::string name = args[1];
+
+    Room room;
+    room.Create(name);
+
+    while(true) {
+      std::cout << "Okay" << std::endl;
+      std::this_thread::sleep_for(2s);
+    }
+
+    room.Destroy();   
+
+    return 0;
+}


### PR DESCRIPTION
# DO NOT MERGE THIS

---

This is a prototype for the Qt GUI. It's really hacked together and not functional yet.
I'm playing around with design ideas and try to figure out what we'll need in the lobby / room classes to communicate with the frontend.

(Uploaded so nobody starts working on this from scratch; we'll probably want to rewrite / refactor this A LOT, but it's already a collection of ideas and some useful bits of Qt code)

TODO:
- [ ] Rename RoomDestroyed to RoomNotFound
- [ ] Remove dead code
- [ ] Add handlers for chat messages
- [x] Add routines to add chat or status messages to the log
- [ ] Add some state to handle disconnected / connected mode switches
- [ ] Synchronize the playerlist using a slot for OnRoomInformationChanged.. or something
- [ ] Move to a seperate repo / project / folder w/e
- [ ] Refactor all the code etc.
- [ ] Seperate the sample / unit test code

Follow-ups / issues:
- [ ] Room-Viewer: Blend wifi reception icons + a channel index to symbolize where each person is communicating and how much
- [ ] Room-Viewer: Block sending empty messages by disabling the "Say" button in the GUI if the chat field is empty
- [ ] Room-List: Block connecting with empty nickname or empty server address by disabling Connect button in GUI