### PR TITLE
Fix RakNet submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "externals/rakNet"]
-	path = externals/rakNet
+[submodule "externals/RakNet"]
+	path = externals/RakNet
 	url = git://github.com/OculusVR/RakNet


### PR DESCRIPTION
We currently use `RakNet` in the CMake but the submodule is `rakNet`.

This changes the submodule to also be `RakNet`