### PR TITLE
Mac address generator

### DIFF
--- a/include/tunnler/room.h
+++ b/include/tunnler/room.h
@@ -18,6 +18,9 @@
 
 const uint16_t DefaultRoomPort = 1234;
 
+// This MAC address is used to generate a 'Nintendo' like Mac address.
+const MacAddress NintendoOUI = { 0x00, 0x1F, 0x32, 0x00, 0x00, 0x00 };
+
 // This is what a server [person creating a server] would use.
 class Room final {
 public:
@@ -91,7 +94,8 @@ private:
     bool IsValidMacAddress(const MacAddress& address);
 
     /**
-     * Generates a free MAC address to assign to a new client.
+     * Generates a free MAC address to assign to a new client. 
+     * The first 3 bytes are the NintendoOUI 0x00, 0x1F, 0x32
      */
     MacAddress GenerateMacAddress();
 

--- a/include/tunnler/room_member.h
+++ b/include/tunnler/room_member.h
@@ -138,12 +138,17 @@ private:
 
     std::unique_ptr<std::thread> receive_thread; ///< Thread that receives and dispatches network packets
 
+    /// Max size of the data queue before the oldest entry is expunged.
+    /// TODO(Ben): Find a good value for this
+    static const size_t MaxDataQueueSize = 100;
+
     /// Max size of the beacon queue before the oldest entry is expunged.
     /// This number was empirically calculated, keeping too many frames will
     // cause an overflow in UDS::RecvBeaconBroadcastData.
     static const size_t MaxBeaconQueueSize = 25;
 
     std::deque<ChatEntry> chat_queue;    ///< List of all chat messages received since last PopChatEntries was called
+    std::mutex data_mutex;             ///< Mutex to protect access to the data queue.
     std::deque<WifiPacket> data_queue;   ///< List of all received 802.11 frames with type `Data`
     std::mutex beacon_mutex;             ///< Mutex to protect access to the beacons queue.
     std::deque<WifiPacket> beacon_queue; ///< List of all received 802.11 frames with type `Beacon`

--- a/include/tunnler/room_member.h
+++ b/include/tunnler/room_member.h
@@ -85,7 +85,7 @@ public:
      * Returns a list of received 802.11 frames from the specified sender
      * matching the type since the last call.
      */
-    std::deque<WifiPacket> PopWifiPackets(WifiPacket::PacketType type, const MacAddress& sender);
+    std::deque<WifiPacket> PopWifiPackets(WifiPacket::PacketType type, const MacAddress& sender = NoPreferredMac);
 
     /**
      * Sends a chat message to the room.

--- a/src/room.cpp
+++ b/src/room.cpp
@@ -2,6 +2,9 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cstdlib>
+#include <ctime>
+
 #include "tunnler/room.h"
 #include "tunnler/room_message_types.h"
 
@@ -19,6 +22,9 @@ void Room::Create(const std::string& name, const std::string& server_address, ui
     server->SetMaximumIncomingConnections(MaxConcurrentConnections);
 
     state = State::Open;
+
+    //Generate seed for MAC Address generator
+    std::srand(std::time(0));
 
     // Start a network thread to Receive packets in a loop.
     room_thread = std::make_unique<std::thread>(&Room::ServerLoop, this);
@@ -175,6 +181,12 @@ void Room::BroadcastRoomInformation() {
 }
 
 MacAddress Room::GenerateMacAddress() {
-    // TODO(Subv): Generate a random mac address here.
-    return {};
+    MacAddress result_mac=NintendoOUI;
+    do {
+        for(int i = 0; i < 3; ++i) {
+            int randNum = std::rand()%(256);
+            result_mac[i] = randNum;
+        }
+    } while(!IsValidMacAddress(result_mac));
+    return result_mac;
 }

--- a/src/room_member.cpp
+++ b/src/room_member.cpp
@@ -61,8 +61,15 @@ void RoomMember::HandleWifiPackets(const RakNet::Packet* packet) {
         if (beacon_queue.size() > MaxBeaconQueueSize) {
             beacon_queue.pop_front();
         }
-    } else {
-        // TODO(Subv): Add to ringbuffer for data / non-beacons
+    } else {  // For now we will treat all non-beacons as data packets
+        std::lock_guard<std::mutex> lock(data_mutex);
+        data_queue.emplace_back(std::move(wifi_packet));
+
+        // If we have more than the max number of buffered data packets, discard the oldest one
+        if (data_queue.size() > MaxDataQueueSize) {
+            data_queue.pop_front();
+        }
+
     }
 }
 
@@ -84,8 +91,23 @@ std::deque<WifiPacket> RoomMember::PopWifiPackets(WifiPacket::PacketType type, c
             }
         }
         return result_queue;
-    } else {
-        return {};
+    } else {  // For now we will treat all non-beacons as data packets
+        std::lock_guard<std::mutex> lock(data_mutex);
+        std::deque<WifiPacket> result_queue;
+        if(mac_address == NoPreferredMac) {         // Don't apply an address filter
+            result_queue = std::move(data_queue);
+            data_queue.clear();
+        } else {                                    // Apply the address filter
+            for(auto it = data_queue.begin(); it != data_queue.end();) {
+                if(it->transmitter_address == mac_address) {
+                    result_queue.emplace_back(std::move(*it));
+                    it = data_queue.erase(it);
+                }else {
+                    ++it;
+                }
+            }
+        }
+        return result_queue;
     }
 }
 


### PR DESCRIPTION
Implemented a mac address generator. The first 3 bytes are always 0x00 0x1F 0x32. This is a Nintendo OUI used with the 3ds. This ensures that none of the specials bits used with mac addresses isn't set. This isn't important for citra<->citra communication but gets important as soon as we send these data into real wifi. Also it ensures if any game would check for a nintendo vendor mac address. (I really doubt that, but just in case).

The last 3 bytes are generated randomly between 0x00 and 0xFF, each. 

The mac is transferred to the member with Room::SendJoinRequest, but isn't handled there, yet.