### PR TITLE
Implemented MAC address generator

### DIFF
--- a/include/tunnler/room.h
+++ b/include/tunnler/room.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <random>
 #include <string>
 #include <thread>
 #include <vector>
@@ -38,7 +39,7 @@ public:
 
     using MemberList = std::vector<Member>;
 
-    Room() { }
+    Room(): random_gen(std::random_device()()) { }
     ~Room() { }
 
     /**
@@ -65,6 +66,8 @@ private:
     RoomInformation room_information; ///< Information about this room.
     MemberList members; ///< Information about the members of this room.
     std::unique_ptr<std::thread> room_thread; ///< Thread that receives and dispatches network packets
+
+    std::mt19937 random_gen; ///< Random number generator. Used for GenerateMacAddress
 
     RakNet::RakPeerInterface* server = nullptr; ///< RakNet network interface.
 

--- a/include/tunnler/room.h
+++ b/include/tunnler/room.h
@@ -18,6 +18,9 @@
 
 const uint16_t DefaultRoomPort = 1234;
 
+// This MAC address is used to generate a 'Nintendo' like Mac address.
+const MacAddress NintendoOUI = { 0x00, 0x1F, 0x32, 0x00, 0x00, 0x00 };
+
 // This is what a server [person creating a server] would use.
 class Room final {
 public:
@@ -102,6 +105,7 @@ private:
 
     /**
      * Generates a free MAC address to assign to a new client.
+     * The first 3 bytes are the NintendoOUI 0x00, 0x1F, 0x32
      */
     MacAddress GenerateMacAddress();
 

--- a/include/tunnler/room_member.h
+++ b/include/tunnler/room_member.h
@@ -129,6 +129,7 @@ private:
     RakNet::RakPeerInterface* peer; ///< RakNet network interface.
 
     std::string nickname; ///< The nickname of this member.
+    MacAddress mac_address; ///< The mac_address of this member.
 
     /**
      * Extracts a WifiPacket from a received RakNet packet and adds it to the proper queue.
@@ -141,6 +142,12 @@ private:
      * @param packet The RakNet packet that was received.
      */
     void HandleRoomInformationPacket(const RakNet::Packet* packet);
+
+    /**
+     * Extracts a MAC Address from a received RakNet packet.
+     * @param packet The RakNet packet that was received.
+     */
+    void HandleJoinPacket(const RakNet::Packet* packet);
 
     std::unique_ptr<std::thread> receive_thread; ///< Thread that receives and dispatches network packets
 

--- a/src/room.cpp
+++ b/src/room.cpp
@@ -2,6 +2,9 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cstdlib>
+#include <ctime>
+
 #include "tunnler/room.h"
 #include "tunnler/room_message_types.h"
 
@@ -19,6 +22,9 @@ void Room::Create(const std::string& name, const std::string& server_address, ui
     server->SetMaximumIncomingConnections(MaxConcurrentConnections);
 
     state = State::Open;
+
+    //Generate seed for MAC Address generator
+    std::srand(std::time(0));
 
     // Start a network thread to Receive packets in a loop.
     room_thread = std::make_unique<std::thread>(&Room::ServerLoop, this);
@@ -186,6 +192,12 @@ void Room::BroadcastRoomInformation() {
 }
 
 MacAddress Room::GenerateMacAddress() {
-    // TODO(Subv): Generate a random mac address here.
-    return {};
+    MacAddress result_mac=NintendoOUI;
+    do {
+        for(int i = 3; i <= 5; ++i) {
+            int randNum = std::rand()%(256);   //Random byte between 0 and 0xFF
+            result_mac[i] = randNum;
+        }
+    } while(!IsValidMacAddress(result_mac));
+    return result_mac;
 }

--- a/src/room.cpp
+++ b/src/room.cpp
@@ -2,9 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <cstdlib>
-#include <ctime>
-
 #include "tunnler/room.h"
 #include "tunnler/room_message_types.h"
 
@@ -22,9 +19,6 @@ void Room::Create(const std::string& name, const std::string& server_address, ui
     server->SetMaximumIncomingConnections(MaxConcurrentConnections);
 
     state = State::Open;
-
-    //Generate seed for MAC Address generator
-    std::srand(std::time(0));
 
     // Start a network thread to Receive packets in a loop.
     room_thread = std::make_unique<std::thread>(&Room::ServerLoop, this);
@@ -192,12 +186,12 @@ void Room::BroadcastRoomInformation() {
 }
 
 MacAddress Room::GenerateMacAddress() {
-    MacAddress result_mac=NintendoOUI;
+    MacAddress result_mac = NintendoOUI;
+    std::uniform_real_distribution<uint8_t> dis(0, 256); //Random byte between 0 and 0xFF
     do {
-        for(int i = 3; i <= 5; ++i) {
-            int randNum = std::rand()%(256);   //Random byte between 0 and 0xFF
-            result_mac[i] = randNum;
+        for (int i = 3; i < result_mac.size(); ++i) {
+            result_mac[i] = dis(random_gen);
         }
-    } while(!IsValidMacAddress(result_mac));
+    } while (!IsValidMacAddress(result_mac));
     return result_mac;
 }

--- a/src/room_member.cpp
+++ b/src/room_member.cpp
@@ -71,7 +71,6 @@ void RoomMember::HandleWifiPackets(const RakNet::Packet* packet) {
     }
 }
 
-
 void RoomMember::HandleRoomInformationPacket(const RakNet::Packet* packet) {
     RakNet::BitStream stream(packet->data, packet->length, false);
 
@@ -100,6 +99,15 @@ void RoomMember::HandleRoomInformationPacket(const RakNet::Packet* packet) {
     }
 }
 
+void RoomMember::HandleJoinPacket(const RakNet::Packet* packet) {
+    RakNet::BitStream stream(packet->data, packet->length, false);
+
+    // Ignore the first byte, which is the message id.
+    stream.IgnoreBytes(sizeof(RakNet::MessageID));
+
+    //Parse the MAC Address from the BitStream
+    stream.Read(mac_address);
+}
 
 std::deque<WifiPacket> RoomMember::PopWifiPackets(WifiPacket::PacketType type, const MacAddress& mac_address) {
     auto FilterAndPopPackets = [&](std::deque<WifiPacket>& source_queue) {
@@ -188,6 +196,7 @@ void RoomMember::ReceiveLoop() {
                 // The join request was successful, we are now in the room.
                 // If we joined successfully, there must be at least one client in the room: us.
                 ASSERT_MSG(GetMemberInformation().size() > 0, "We have not yet received member information.");
+                HandleJoinPacket(packet);    // Get the MAC Address for the client
                 state = State::Joined;
                 break;
             case ID_DISCONNECTION_NOTIFICATION:


### PR DESCRIPTION
Implemented a mac address generator. The first 3 bytes are always 0x00 0x1F 0x32. This is a Nintendo OUI used with the 3ds. This ensures that none of the specials bits used with mac addresses isn't set. This isn't important for citra<->citra communication but gets important as soon as we send these data into real wifi. Also it ensures if any game would check for a nintendo vendor mac address. (I really doubt that, but just in case).

The last 3 bytes are generated randomly between 0x00 and 0xFF, each.

The mac is transferred to the member with Room::SendJoinRequest, but isn't handled there, yet.