### PR TITLE
Revert "Transfer the client_port to SocketDescriptor (#15)"

### DIFF
--- a/src/room_member.cpp
+++ b/src/room_member.cpp
@@ -236,7 +236,8 @@ void RoomMember::ReceiveLoop() {
 };
 
 void RoomMember::Join(const std::string& nickname, const std::string& server, uint16_t server_port, uint16_t client_port) {
-    RakNet::SocketDescriptor socket(client_port, 0);
+    // TODO(Subv): Use client_port.
+    RakNet::SocketDescriptor socket;
     peer->Startup(1, &socket, 1);
 
     RakNet::ConnectionAttemptResult result = peer->Connect(server.c_str(), server_port, nullptr, 0);


### PR DESCRIPTION
This reverts commit 8bd7faa0d0e8080a77964bd362cb823d19b72a21.

Let's just revert it for now, since it causes some unexplainable problems. 
We can implement this in a later stage.