### PR TITLE
Fixed Leave in RoomMember

### DIFF
--- a/include/tunnler/room_member.h
+++ b/include/tunnler/room_member.h
@@ -33,7 +33,7 @@ public:
         Error,    // Some error [permissions to network device missing or something]
         Joining,  // The client is attempting to join a room.
         Joined,   // The client is connected to the room and is ready to send/receive packets.
-        Leave,    // The client is about to close the connection
+        Leaving,    // The client is about to close the connection
 
         // Reasons for connection loss
         LostConnection,

--- a/include/tunnler/room_member.h
+++ b/include/tunnler/room_member.h
@@ -33,6 +33,7 @@ public:
         Error,    // Some error [permissions to network device missing or something]
         Joining,  // The client is attempting to join a room.
         Joined,   // The client is connected to the room and is ready to send/receive packets.
+        Leave,    // The client is about to close the connection
 
         // Reasons for connection loss
         LostConnection,

--- a/src/room_member.cpp
+++ b/src/room_member.cpp
@@ -168,7 +168,7 @@ static void SendJoinRequest(RakNet::RakPeerInterface* peer, const std::string& n
 }
 
 void RoomMember::ReceiveLoop() {
-    bool shutdown(false);
+    bool shutdown = false;
     // Receive packets while the connection is open
     while (IsConnected()) {
         std::lock_guard<std::mutex> lock(network_mutex);
@@ -187,11 +187,11 @@ void RoomMember::ReceiveLoop() {
                 break;
             case ID_ROOM_NAME_COLLISION:
                 state = State::NameCollision;
-                shutdown=true;
+                shutdown = true;
                 break;
             case ID_ROOM_MAC_COLLISION:
                 state = State::MacCollision;
-                shutdown=true;
+                shutdown = true;
                 break;
             case ID_ROOM_JOIN_SUCCESS:
                 // The join request was successful, we are now in the room.
@@ -203,24 +203,24 @@ void RoomMember::ReceiveLoop() {
             case ID_DISCONNECTION_NOTIFICATION:
                 // Connection lost normally
                 state = State::Idle;
-                shutdown=true;
+                shutdown = true;
                 break;
             case ID_INCOMPATIBLE_PROTOCOL_VERSION:
                 state = State::WrongVersion;
-                shutdown=true;
+                shutdown = true;
                 break;
             case ID_CONNECTION_ATTEMPT_FAILED:
                 state = State::Error;
-                shutdown=true;
+                shutdown = true;
                 break;
             case ID_NO_FREE_INCOMING_CONNECTIONS:
                 state = State::RoomFull;
-                shutdown=true;
+                shutdown = true;
                 break;
             case ID_CONNECTION_LOST:
                 // Couldn't deliver a reliable packet, the other system was abnormally terminated
                 state = State::LostConnection;
-                shutdown=true;
+                shutdown = true;
                 break;
             case ID_CONNECTION_REQUEST_ACCEPTED:
                 // Update the server address with the address of the sender of this packet.
@@ -232,16 +232,17 @@ void RoomMember::ReceiveLoop() {
             }
 
             peer->DeallocatePacket(packet);
-            if(!IsConnected())      //Don't parse any more packets if we should shutdown
-                shutdown=true;
         }
     }
     peer->Shutdown(300);
 };
 
 void RoomMember::Join(const std::string& nickname, const std::string& server, uint16_t server_port, uint16_t client_port) {
-    if(receive_thread.get())    // We are still joined
+    if (receive_thread) {
+        // We are still joined
         Leave();
+    }
+
     RakNet::SocketDescriptor socket(client_port, 0);
     peer->Startup(1, &socket, 1);
 
@@ -264,9 +265,8 @@ bool RoomMember::IsConnected() const {
 
 void RoomMember::Leave() {
     ASSERT_MSG(receive_thread != nullptr, "Must be in a room to leave it.");
-    state = State::Leave;
+    state = State::Leaving;
     receive_thread->join();
     receive_thread.reset();
-    peer->Shutdown(300);
     state = State::Idle;
 }


### PR DESCRIPTION
Assured that deallocate packet is only called as long as RoomMember isConnected
This fixes https://github.com/B3n30/tunnler/issues/30